### PR TITLE
feat: Add GET endpoint for retrieving Tapis job status

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,3 +10,6 @@ VERSION=v1
 
 # Redis Configuration
 REDIS_URL=redis://localhost:6379
+
+# Tapis Configuration
+TAPIS_BASE_PATH=https://portals.tapis.io

--- a/src/api/api-v1/paths/tapis/jobs/{id}.ts
+++ b/src/api/api-v1/paths/tapis/jobs/{id}.ts
@@ -6,14 +6,34 @@ import { JobsService } from "../../../services/tapis/jobsService";
 export default function (jobsService: JobsService) {
     const exports = {
         POST,
+        GET,
         parameters: [
             {
                 in: "path",
                 name: "id",
-                example: "bae0f0be-6dbe-e791-f184-1c20f9903afc"
+                example: "d0cd5bb7-922e-46b1-9f9b-331e2cf1e73b-007"
             }
         ]
     };
+
+    async function GET(req: any, res: Response) {
+        const authHeader = req.headers.authorization;
+        if (!authHeader || !authHeader.startsWith("Bearer ")) {
+            return false;
+        }
+
+        const access_token = authHeader.split(" ")[1];
+        try {
+            const job = await jobsService.get(req.params.id, access_token);
+            res.status(200).send({
+                message: "Job Status",
+                status: job
+            });
+        } catch (error) {
+            console.error(error);
+            return res.status(500).send({ message: error.message });
+        }
+    }
 
     async function POST(req: any, res: Response) {
         try {
@@ -28,11 +48,32 @@ export default function (jobsService: JobsService) {
             });
         } catch (error) {
             console.error(error);
-            return res.status(500).send({ message: "An error occurred. " + error });
+            return res.status(500).send({ message: "An error occurred. " + error.message });
         }
     }
 
     // NOTE: We could also use a YAML string here.
+    GET.apiDoc = {
+        summary: "Get Job Status",
+        description: "Get the status of a job.",
+        operationId: "tapisGetJobStatus",
+        tags: ["Tapis"],
+        security: [
+            {
+                BearerAuth: [],
+                oauth2: []
+            }
+        ],
+        responses: {
+            "200": {
+                description: "Job Status"
+            },
+            default: {
+                description: "An error occurred"
+            }
+        }
+    };
+
     POST.apiDoc = {
         summary: "Webhook for Job Status Change.",
         description:

--- a/src/api/api-v1/services/tapis/jobsService.ts
+++ b/src/api/api-v1/services/tapis/jobsService.ts
@@ -1,8 +1,10 @@
 import { Execution } from "../../../../classes/mint/mint-types";
 import handleExecutionEvent from "../../../../classes/tapis/handle-execution-event";
+import get from "../../../../classes/tapis/api/jobs/get";
 
 export interface JobsService {
     webhookJobStatusChange(webHookEvent: any, executionId: string): Promise<Execution | undefined>;
+    get(jobId: string, access_token: string): Promise<string>;
 }
 
 const jobsService = {
@@ -11,6 +13,11 @@ const jobsService = {
         executionId: string
     ): Promise<Execution | undefined> {
         return await handleExecutionEvent(webHookEvent.event, executionId);
+    },
+
+    async get(jobId: string, access_token: string): Promise<string> {
+        const job = await get(jobId, access_token);
+        return job.status;
     }
 };
 

--- a/src/classes/tapis/api/jobs/get.ts
+++ b/src/classes/tapis/api/jobs/get.ts
@@ -1,0 +1,12 @@
+import { Jobs } from "@mfosorio/tapis-typescript";
+import apiGenerator from "../../utils/apiGenerator";
+import errorDecoder from "../../utils/errorDecoder";
+
+const basePath = process.env.TAPIS_BASE_PATH;
+
+const get = (jobId: string, jwt: string): Promise<Jobs.RespGetJob> => {
+    const api: Jobs.JobsApi = apiGenerator<Jobs.JobsApi>(Jobs, Jobs.JobsApi, basePath, jwt);
+    return errorDecoder<Jobs.RespGetJob>(() => api.getJob({ jobUuid: jobId }));
+};
+
+export default get;


### PR DESCRIPTION
- Implement GET method for job status retrieval
- Add new Tapis job get method in jobsService
- Create new get.ts class for Tapis job API interaction
- Update .env.sample with Tapis base path configuration
- Add OpenAPI documentation for the new GET endpoint
