### PR TITLE
feat: add tapis execution output registration

### DIFF
--- a/src/api/api-v1/paths/tapis/executions/{executionId}/outputs.ts
+++ b/src/api/api-v1/paths/tapis/executions/{executionId}/outputs.ts
@@ -1,0 +1,68 @@
+import { Response } from "express";
+import { ExecutionOutputsService } from "@/api/api-v1/services/tapis/executionOutputsService";
+
+export default function (executionOutputsService: ExecutionOutputsService) {
+    const exports = {
+        POST,
+        parameters: [
+            {
+                in: "path",
+                name: "executionId",
+                required: true,
+                schema: {
+                    type: "string"
+                }
+            }
+        ]
+    };
+
+    async function POST(req: any, res: Response) {
+        try {
+            const success = await executionOutputsService.registerOutputs(
+                req.params.executionId,
+                req.headers.authorization
+            );
+
+            if (success) {
+                res.status(200).json({
+                    message: "Execution outputs registered successfully"
+                });
+            } else {
+                res.status(400).json({
+                    message: "Failed to register execution outputs"
+                });
+            }
+        } catch (error) {
+            console.error(error);
+            res.status(500).json({
+                message: error.message
+            });
+        }
+    }
+
+    POST.apiDoc = {
+        summary: "Register Tapis Execution Outputs",
+        description: "Register the outputs of a successful Tapis execution in the data catalog",
+        operationId: "registerTapisExecutionOutputs",
+        tags: ["Tapis"],
+        security: [
+            {
+                BearerAuth: [],
+                oauth2: []
+            }
+        ],
+        responses: {
+            "200": {
+                description: "Outputs registered successfully"
+            },
+            "400": {
+                description: "Invalid request or registration failed"
+            },
+            "500": {
+                description: "Server error"
+            }
+        }
+    };
+
+    return exports;
+}

--- a/src/api/api-v1/paths/tapis/modelEnsembles/{id}/outputs.ts
+++ b/src/api/api-v1/paths/tapis/modelEnsembles/{id}/outputs.ts
@@ -1,13 +1,13 @@
 import { Response } from "express";
-import { ThreadsOutputsService } from "@/api/api-v1/services/tapis/threads/outputs/threadsOutputsService";
+import { ModelEnsemblesOutputsService } from "@/api/api-v1/services/tapis/modelEnsembles/outputs/modelEnsemblesOutputsService";
 
-export default function (threadsOutputsService: ThreadsOutputsService) {
+export default function (modelEnsemblesOutputsService: ModelEnsemblesOutputsService) {
     const exports = {
         POST,
         parameters: [
             {
                 in: "path",
-                name: "threadId",
+                name: "id",
                 required: true,
                 schema: {
                     type: "string"
@@ -19,11 +19,11 @@ export default function (threadsOutputsService: ThreadsOutputsService) {
     async function POST(req: any, res: Response) {
         try {
             // Start the registration process asynchronously
-            threadsOutputsService.registerOutputs(req.params.threadId, req.headers.authorization);
+            modelEnsemblesOutputsService.registerOutputs(req.params.id, req.headers.authorization);
 
             // Return immediate acknowledgment
             res.status(202).json({
-                message: "Thread outputs registration process started"
+                message: "Model ensemble outputs registration process started"
             });
         } catch (error) {
             console.error(error);
@@ -34,10 +34,10 @@ export default function (threadsOutputsService: ThreadsOutputsService) {
     }
 
     POST.apiDoc = {
-        summary: "Register Thread Execution Outputs",
+        summary: "Register Model Ensemble Execution Outputs",
         description:
-            "Register all execution outputs for a thread in the data catalog asynchronously",
-        operationId: "registerThreadExecutionOutputs",
+            "Register all execution outputs for a model ensemble in the data catalog asynchronously",
+        operationId: "registerModelEnsembleExecutionOutputs",
         tags: ["Tapis"],
         security: [
             {

--- a/src/api/api-v1/paths/tapis/threads/{threadId}/outputs.ts
+++ b/src/api/api-v1/paths/tapis/threads/{threadId}/outputs.ts
@@ -1,0 +1,59 @@
+import { Response } from "express";
+import { ThreadsOutputsService } from "@/api/api-v1/services/tapis/threads/outputs/threadsOutputsService";
+
+export default function (threadsOutputsService: ThreadsOutputsService) {
+    const exports = {
+        POST,
+        parameters: [
+            {
+                in: "path",
+                name: "threadId",
+                required: true,
+                schema: {
+                    type: "string"
+                }
+            }
+        ]
+    };
+
+    async function POST(req: any, res: Response) {
+        try {
+            // Start the registration process asynchronously
+            threadsOutputsService.registerOutputs(req.params.threadId, req.headers.authorization);
+
+            // Return immediate acknowledgment
+            res.status(202).json({
+                message: "Thread outputs registration process started"
+            });
+        } catch (error) {
+            console.error(error);
+            res.status(500).json({
+                message: error.message
+            });
+        }
+    }
+
+    POST.apiDoc = {
+        summary: "Register Thread Execution Outputs",
+        description:
+            "Register all execution outputs for a thread in the data catalog asynchronously",
+        operationId: "registerThreadExecutionOutputs",
+        tags: ["Tapis"],
+        security: [
+            {
+                BearerAuth: [],
+                oauth2: []
+            }
+        ],
+        responses: {
+            "202": {
+                description: "Registration process started"
+            },
+            "500": {
+                description: "Server error"
+            }
+        }
+    };
+
+    return exports;
+}

--- a/src/api/api-v1/services/tapis/executionOutputsService.ts
+++ b/src/api/api-v1/services/tapis/executionOutputsService.ts
@@ -1,0 +1,23 @@
+import { TapisExecutionService } from "@/classes/tapis/adapters/TapisExecutionService";
+import { getTokenFromAuthorizationHeader } from "@/utils/authUtils";
+import { getConfiguration } from "@/classes/mint/mint-functions";
+
+export interface ExecutionOutputsService {
+    registerOutputs(executionId: string, authorization: string): Promise<boolean>;
+}
+
+const executionOutputsService: ExecutionOutputsService = {
+    async registerOutputs(executionId: string, authorization: string): Promise<boolean> {
+        const token = getTokenFromAuthorizationHeader(authorization);
+        if (!token) {
+            throw new Error("Unauthorized");
+        }
+
+        const prefs = getConfiguration();
+        const tapisExecution = new TapisExecutionService(token, prefs.tapis.basePath);
+        await tapisExecution.registerExecutionOutputs(executionId);
+        return true;
+    }
+};
+
+export default executionOutputsService;

--- a/src/api/api-v1/services/tapis/modelEnsembles/outputs/modelEnsemblesOutputsService.ts
+++ b/src/api/api-v1/services/tapis/modelEnsembles/outputs/modelEnsemblesOutputsService.ts
@@ -7,12 +7,12 @@ import {
 import { TapisExecutionService } from "@/classes/tapis/adapters/TapisExecutionService";
 import { getTokenFromAuthorizationHeader } from "@/utils/authUtils";
 
-export interface ThreadsOutputsService {
-    registerOutputs(threadId: string, authorization: string): void;
+export interface ModelEnsemblesOutputsService {
+    registerOutputs(modelEnsembleId: string, authorization: string): void;
 }
 
-const threadsOutputsService: ThreadsOutputsService = {
-    async registerOutputs(threadId: string, authorization: string): Promise<void> {
+const modelEnsemblesOutputsService: ModelEnsemblesOutputsService = {
+    async registerOutputs(modelEnsembleId: string, authorization: string): Promise<void> {
         const token = getTokenFromAuthorizationHeader(authorization);
         if (!token) {
             throw new Error("Unauthorized");
@@ -21,21 +21,21 @@ const threadsOutputsService: ThreadsOutputsService = {
         const prefs = getConfiguration();
         const tapisExecution = new TapisExecutionService(token, prefs.tapis.basePath);
 
-        // Get all execution IDs for the thread
-        const executionIds = await getThreadModelExecutionIds(threadId);
+        // Get all execution IDs for the model ensemble
+        const executionIds = await getThreadModelExecutionIds(modelEnsembleId);
 
-        toggleThreadModelExecutionSummaryPublishing(threadId, true);
+        toggleThreadModelExecutionSummaryPublishing(modelEnsembleId, true);
         // Process each execution asynchronously without waiting
         for (const executionId of executionIds) {
             try {
                 await tapisExecution.registerExecutionOutputs(executionId);
-                await incrementPublishedRuns(threadId);
+                await incrementPublishedRuns(modelEnsembleId);
             } catch (error) {
                 console.error(`Error registering outputs for execution ${executionId}:`, error);
             }
         }
-        toggleThreadModelExecutionSummaryPublishing(threadId, false);
+        toggleThreadModelExecutionSummaryPublishing(modelEnsembleId, false);
     }
 };
 
-export default threadsOutputsService;
+export default modelEnsemblesOutputsService;

--- a/src/api/api-v1/services/tapis/threads/outputs/threadsOutputsService.ts
+++ b/src/api/api-v1/services/tapis/threads/outputs/threadsOutputsService.ts
@@ -1,0 +1,41 @@
+import { getConfiguration } from "@/classes/mint/mint-functions";
+import {
+    getThreadModelExecutionIds,
+    incrementPublishedRuns,
+    toggleThreadModelExecutionSummaryPublishing
+} from "@/classes/graphql/graphql_functions";
+import { TapisExecutionService } from "@/classes/tapis/adapters/TapisExecutionService";
+import { getTokenFromAuthorizationHeader } from "@/utils/authUtils";
+
+export interface ThreadsOutputsService {
+    registerOutputs(threadId: string, authorization: string): void;
+}
+
+const threadsOutputsService: ThreadsOutputsService = {
+    async registerOutputs(threadId: string, authorization: string): Promise<void> {
+        const token = getTokenFromAuthorizationHeader(authorization);
+        if (!token) {
+            throw new Error("Unauthorized");
+        }
+
+        const prefs = getConfiguration();
+        const tapisExecution = new TapisExecutionService(token, prefs.tapis.basePath);
+
+        // Get all execution IDs for the thread
+        const executionIds = await getThreadModelExecutionIds(threadId);
+
+        toggleThreadModelExecutionSummaryPublishing(threadId, true);
+        // Process each execution asynchronously without waiting
+        for (const executionId of executionIds) {
+            try {
+                await tapisExecution.registerExecutionOutputs(executionId);
+                await incrementPublishedRuns(threadId);
+            } catch (error) {
+                console.error(`Error registering outputs for execution ${executionId}:`, error);
+            }
+        }
+        toggleThreadModelExecutionSummaryPublishing(threadId, false);
+    }
+};
+
+export default threadsOutputsService;

--- a/src/classes/graphql/graphql_functions.ts
+++ b/src/classes/graphql/graphql_functions.ts
@@ -51,7 +51,7 @@ import updateExecutionSummary from "./queries/execution/update-execution-summary
 import incFailedRunsGQL from "./queries/execution/increment-failed-runs.graphql";
 import incSuccessfulRunsGQL from "./queries/execution/increment-successful-runs.graphql";
 import incSubmittedRunsGQL from "./queries/execution/increment-submitted-runs.graphql";
-import toggleThreadModelExecutionSummaryPublishingGQL from "./queries/execution/toggle-thread-model-execution-summary-publishing.graphql";
+import toggleThreadModelExecutionSummaryPublishingGQL from "./queries/execution/toggle-summary-publishing.graphql";
 import incRegisteredRunsGQL from "./queries/execution/increment-registered-runs.graphql";
 import incRegisteredRunsByExecutionIdGQL from "./queries/execution/increment-registered-runs-by-execution-id.graphql";
 

--- a/src/classes/graphql/graphql_functions.ts
+++ b/src/classes/graphql/graphql_functions.ts
@@ -51,6 +51,7 @@ import updateExecutionSummary from "./queries/execution/update-execution-summary
 import incFailedRunsGQL from "./queries/execution/increment-failed-runs.graphql";
 import incSuccessfulRunsGQL from "./queries/execution/increment-successful-runs.graphql";
 import incSubmittedRunsGQL from "./queries/execution/increment-submitted-runs.graphql";
+import toggleThreadModelExecutionSummaryPublishingGQL from "./queries/execution/toggle-thread-model-execution-summary-publishing.graphql";
 import incRegisteredRunsGQL from "./queries/execution/increment-registered-runs.graphql";
 import incRegisteredRunsByExecutionIdGQL from "./queries/execution/increment-registered-runs-by-execution-id.graphql";
 
@@ -63,7 +64,7 @@ import deleteModelGQL from "./queries/model/delete.graphql";
 
 import getModelOutputGQL from "./queries/model_output/get.graphql";
 import getThreadModelGQL from "./queries/thread_model/get.graphql";
-
+import incrementPublishedRunsGQL from "./queries/execution/increment-published-runs.graphql";
 import {
     problemStatementFromGQL,
     taskFromGQL,
@@ -663,6 +664,20 @@ export const setThreadModelExecutionSummary = (
     });
 };
 
+export const toggleThreadModelExecutionSummaryPublishing = (
+    thread_model_id: string,
+    submitted_for_publishing: boolean
+) => {
+    const APOLLO_CLIENT = GraphQL.instance(KeycloakAdapter.getUser());
+    return APOLLO_CLIENT.mutate({
+        mutation: toggleThreadModelExecutionSummaryPublishingGQL,
+        variables: {
+            threadModelId: thread_model_id,
+            submitted_for_publishing: submitted_for_publishing
+        }
+    });
+};
+
 // Increment thread submitted runs
 export const incrementThreadModelSubmittedRuns = (thread_model_id: string, num: number = 1) => {
     const APOLLO_CLIENT = GraphQL.instance(KeycloakAdapter.getUser());
@@ -1064,4 +1079,15 @@ export const getThreadModelByThreadIdExecutionId = async (
         console.log(error);
         return null;
     }
+};
+
+export const incrementPublishedRuns = (threadModelId: string, num: number = 1) => {
+    const APOLLO_CLIENT = GraphQL.instance(KeycloakAdapter.getUser());
+    return APOLLO_CLIENT.mutate({
+        mutation: incrementPublishedRunsGQL,
+        variables: {
+            threadModelId: threadModelId,
+            inc: num
+        }
+    });
 };

--- a/src/classes/graphql/queries/execution/increment-published-runs.graphql
+++ b/src/classes/graphql/queries/execution/increment-published-runs.graphql
@@ -1,0 +1,8 @@
+mutation increment_published_runs($threadModelId: uuid!, $inc: Int!) {
+    update_thread_model_execution_summary_by_pk(
+        pk_columns: { thread_model_id: $threadModelId }
+        _inc: { published_runs: $inc }
+    ) {
+        thread_model_id
+    }
+}

--- a/src/classes/graphql/queries/execution/toggle-summary-publishing.graphql
+++ b/src/classes/graphql/queries/execution/toggle-summary-publishing.graphql
@@ -1,6 +1,6 @@
 mutation toggle_thread_model_execution_summary_publishing(
     $threadModelId: uuid!
-    $submitted_for_publishing: boolean!
+    $submitted_for_publishing: Boolean!
 ) {
     update_thread_model_execution_summary_by_pk(
         pk_columns: { thread_model_id: $threadModelId }

--- a/src/classes/graphql/queries/execution/toggle-summary-publishing.graphql
+++ b/src/classes/graphql/queries/execution/toggle-summary-publishing.graphql
@@ -1,0 +1,11 @@
+mutation toggle_thread_model_execution_summary_publishing(
+    $threadModelId: uuid!
+    $submitted_for_publishing: boolean!
+) {
+    update_thread_model_execution_summary_by_pk(
+        pk_columns: { thread_model_id: $threadModelId }
+        _set: { submitted_for_publishing: $submitted_for_publishing }
+    ) {
+        thread_model_id
+    }
+}

--- a/src/classes/tapis/jobs/index.ts
+++ b/src/classes/tapis/jobs/index.ts
@@ -6,6 +6,7 @@ const matchTapisOutputsToMintOutputs = (
     files: Jobs.FileInfo[],
     mintOutputs: ModelOutput[]
 ): Execution_Result[] => {
+    const PORTAL_URL = "https://ptdatax.tacc.utexas.edu/workbench/data/tapis/private/cloud.data";
     return files
         .flatMap((file) => {
             const modelOutput = mintOutputs.find((output: ModelOutput) => {
@@ -15,11 +16,14 @@ const matchTapisOutputsToMintOutputs = (
             });
             if (!modelOutput) return undefined;
             else {
+                // Transform the Tapis URL to the public portal URL
+                const publicUrl = file.url.replace("tapis://ls6", PORTAL_URL);
+
                 const executionResult: Execution_Result = {
                     resource: {
                         name: file.name,
-                        url: file.url,
-                        id: getMd5Hash(file.url)
+                        url: publicUrl,
+                        id: getMd5Hash(publicUrl)
                         // spatial_coverage: getSpatialCoverageGeometry(data["spatial_coverage"]),
                         // time_period: {}
                     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { PORT, VERSION } from "./config/app";
 import jobsService from "./api/api-v1/services/tapis/jobsService";
 import { getConfiguration } from "./classes/mint/mint-functions";
 import executionOutputsService from "./api/api-v1/services/tapis/executionOutputsService";
+import threadsOutputsService from "./api/api-v1/services/tapis/threads/outputs/threadsOutputsService";
 
 // Main Express Server
 const app = express();
@@ -58,7 +59,8 @@ initialize({
         modelCacheService: v1ModelCacheService,
         executionsTapisService: v1ExecutionTapisService,
         threadsExecutionsService: v1ThreadsExecutionsService,
-        executionOutputsService: executionOutputsService
+        executionOutputsService: executionOutputsService,
+        threadsOutputsService: threadsOutputsService
     },
     paths: path.resolve(__dirname, "./api/api-v1/paths"),
     routesGlob: "**/*.{ts,js}",

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,8 +28,7 @@ import { PORT, VERSION } from "./config/app";
 import jobsService from "./api/api-v1/services/tapis/jobsService";
 import { getConfiguration } from "./classes/mint/mint-functions";
 import executionOutputsService from "./api/api-v1/services/tapis/executionOutputsService";
-import threadsOutputsService from "./api/api-v1/services/tapis/threads/outputs/threadsOutputsService";
-
+import modelEnsemblesOutputsService from "./api/api-v1/services/tapis/modelEnsembles/outputs/modelEnsemblesOutputsService";
 // Main Express Server
 const app = express();
 const port = PORT;
@@ -60,7 +59,7 @@ initialize({
         executionsTapisService: v1ExecutionTapisService,
         threadsExecutionsService: v1ThreadsExecutionsService,
         executionOutputsService: executionOutputsService,
-        threadsOutputsService: threadsOutputsService
+        modelEnsemblesOutputsService: modelEnsemblesOutputsService
     },
     paths: path.resolve(__dirname, "./api/api-v1/paths"),
     routesGlob: "**/*.{ts,js}",

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,8 @@ import { DOWNLOAD_TAPIS_OUTPUT_QUEUE_NAME, EXECUTION_QUEUE_NAME, REDIS_URL } fro
 import { PORT, VERSION } from "./config/app";
 import jobsService from "./api/api-v1/services/tapis/jobsService";
 import { getConfiguration } from "./classes/mint/mint-functions";
+import executionOutputsService from "./api/api-v1/services/tapis/executionOutputsService";
+
 // Main Express Server
 const app = express();
 const port = PORT;
@@ -55,7 +57,8 @@ initialize({
         logsService: v1LogsService,
         modelCacheService: v1ModelCacheService,
         executionsTapisService: v1ExecutionTapisService,
-        threadsExecutionsService: v1ThreadsExecutionsService
+        threadsExecutionsService: v1ThreadsExecutionsService,
+        executionOutputsService: executionOutputsService
     },
     paths: path.resolve(__dirname, "./api/api-v1/paths"),
     routesGlob: "**/*.{ts,js}",


### PR DESCRIPTION
# Add Tapis Execution Outputs Registration

## Summary
This PR adds new endpoints and services to handle the registration of Tapis execution outputs and model ensemble outputs in the data catalog.

## Changes
- Added new endpoints:
  - `/tapis/executions/{executionId}/outputs` - Register outputs for a single execution
  - `/tapis/modelEnsembles/{id}/outputs` - Register outputs for all executions in a model ensemble

- Added new services:
  - `ExecutionOutputsService` - Handles single execution output registration
  - `ModelEnsemblesOutputsService` - Handles asynchronous registration of multiple execution outputs

- Enhanced `TapisExecutionService` with output registration capabilities
- Added new GraphQL mutations for tracking publishing status and published runs
- Updated job output URL handling to use public portal URLs

## Key Features
- Single execution output registration with synchronous response
- Asynchronous model ensemble outputs registration with immediate acknowledgment
- Progress tracking for model ensemble publishing
- Conversion of Tapis URLs to public portal URLs for better accessibility

## Testing
Please test the following scenarios:
1. Single execution output registration
2. Model ensemble output registration
3. URL transformation for output files
4. Publishing status updates in the UI

## API Changes
### New Endpoints:
- `POST /tapis/executions/{executionId}/outputs`
  - Response: 200 (success) or 400/500 (failure)
- `POST /tapis/modelEnsembles/{id}/outputs`
  - Response: 202 (accepted) or 500 (failure)

## Dependencies
No new dependencies were added.

