### PR TITLE
refactor: simplify model handling in subTasksService

### DIFF
--- a/src/api/api-v1/services/subTasksService.ts
+++ b/src/api/api-v1/services/subTasksService.ts
@@ -155,13 +155,11 @@ const subTasksService: SubTasksService = {
             throw new NotFoundError("Subtask not found");
         }
         for (const modelId of modelIds) {
-            const model: ModelConfigurationSetup = await fetchModelConfigurationSetup(modelId);
-            await setThreadModels([model], "Added models", subtask);
+            await setThreadModels([{ id: modelId }], "Added models", subtask);
         }
         return await getThread(subtaskId);
     }
 
-    //     // Get the resources required for each model in the subtask
     //     async findRequiredResources(subtaskId: string, authorizationHeader: string) {
     //         const access_token = getTokenFromAuthorizationHeader(authorizationHeader);
     //         if (!access_token) {

--- a/src/api/api-v1/services/subTasksService.ts
+++ b/src/api/api-v1/services/subTasksService.ts
@@ -1,6 +1,8 @@
 import { Thread, ThreadInfo } from "@/classes/mint/mint-types";
 import {
     addThread,
+    insertModel,
+    getModel,
     getTask,
     getThread,
     setThreadModels
@@ -13,8 +15,16 @@ import {
     BadRequestError
 } from "@/classes/common/errors";
 import problemStatementsService from "./problemStatementsService";
-import { fetchModelConfigurationSetup } from "@/classes/mint/model-catalog-functions";
-import { ModelConfigurationSetup } from "@mintproject/modelcatalog_client/dist";
+import {
+    convertApiUrlToW3Id,
+    fetchModelConfiguration,
+    fetchModelConfigurationSetup
+} from "@/classes/mint/model-catalog-functions";
+import {
+    modelConfigurationSetupToGraphQL,
+    modelConfigurationToGraphQL
+} from "@/classes/mint/model-catalog-graphql-adapter";
+import { Model_Insert_Input } from "@/classes/graphql/graph_typing";
 
 export interface SubTasksService {
     getSubtasksByTaskId(
@@ -155,7 +165,20 @@ const subTasksService: SubTasksService = {
             throw new NotFoundError("Subtask not found");
         }
         for (const modelId of modelIds) {
-            await setThreadModels([{ id: modelId }], "Added models", subtask);
+            const w3Id = convertApiUrlToW3Id(modelId);
+            if (!(await getModel(w3Id))) {
+                let modelConfigurationGraphQL: Model_Insert_Input;
+                try {
+                    const modelConfiguration = await fetchModelConfiguration(w3Id);
+                    modelConfigurationGraphQL = modelConfigurationToGraphQL(modelConfiguration);
+                } catch (error) {
+                    const modelConfigurationSetup = await fetchModelConfigurationSetup(modelId);
+                    modelConfigurationGraphQL =
+                        modelConfigurationSetupToGraphQL(modelConfigurationSetup);
+                }
+                await insertModel([modelConfigurationGraphQL]);
+            }
+            await setThreadModels([{ id: w3Id }], "Added models", subtask);
         }
         return await getThread(subtaskId);
     }

--- a/src/classes/graphql/graphql_functions.ts
+++ b/src/classes/graphql/graphql_functions.ts
@@ -66,6 +66,7 @@ import deleteThreadModelExecutionsGQL from "./queries/execution/delete-thread-mo
 
 import getModelGQL from "./queries/model/get.graphql";
 import deleteModelGQL from "./queries/model/delete.graphql";
+import insertModelGQL from "./queries/model/new.graphql";
 
 import getModelOutputGQL from "./queries/model_output/get.graphql";
 import getThreadModelGQL from "./queries/thread_model/get.graphql";
@@ -94,6 +95,7 @@ import {
 import { Md5 } from "ts-md5";
 import {
     Execution_Result_Insert_Input,
+    Model_Insert_Input,
     Resource_Constraint,
     Resource_Update_Column,
     Thread_Model_Execution_Summary_Insert_Input,
@@ -1191,4 +1193,14 @@ export const getProblemStatements = async (
         console.log(e);
         throw new InternalServerError("Error getting problem statements " + e.message);
     }
+};
+
+export const insertModel = (models: Model_Insert_Input[]) => {
+    const APOLLO_CLIENT = GraphQL.instance(KeycloakAdapter.getUser());
+    return APOLLO_CLIENT.mutate({
+        mutation: insertModelGQL,
+        variables: {
+            objects: models
+        }
+    });
 };

--- a/src/classes/mint/__tests__/model-catalog-functions.test.ts
+++ b/src/classes/mint/__tests__/model-catalog-functions.test.ts
@@ -1,0 +1,107 @@
+import { convertToUrlToCustomUrl, convertApiUrlToW3Id } from "../model-catalog-functions";
+import { getConfiguration } from "../mint-functions";
+import { ModelConfigurationType } from "../model-catalog-functions";
+
+// Mock getConfiguration
+jest.mock("../mint-functions", () => ({
+    getConfiguration: jest.fn().mockReturnValue({
+        model_catalog_api: "https://api.models.mint.local/v1.8.0/",
+        auth_server: "https://auth.mint.local",
+        auth_realm: "mint",
+        auth_client_id: "mint-client",
+        graphql: {
+            endpoint: "http://localhost:8080/v1/graphql",
+            secret: "test-secret",
+            enable_ssl: false
+        }
+    })
+}));
+
+describe("convertToUrlToCustomUrl", () => {
+    it("should convert a model configuration URL to a custom URL with query parameters for ModelConfiguration type", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu";
+        const expected =
+            "https://api.models.mint.local/v1.8.0/custom/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu";
+
+        expect(convertToUrlToCustomUrl(input, ModelConfigurationType.ModelConfiguration)).toBe(
+            expected
+        );
+    });
+
+    it("should convert a model configuration URL to a custom URL with query parameters for ModelConfigurationSetup type", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu";
+        const expected =
+            "https://api.models.mint.local/v1.8.0/custom/modelconfigurationsetups/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu";
+
+        expect(convertToUrlToCustomUrl(input, ModelConfigurationType.ModelConfigurationSetup)).toBe(
+            expected
+        );
+    });
+
+    it("should convert a model configuration URL to a custom URL without query parameters for ModelConfiguration type", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c";
+        const expected =
+            "https://api.models.mint.local/v1.8.0/custom/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c";
+
+        expect(convertToUrlToCustomUrl(input, ModelConfigurationType.ModelConfiguration)).toBe(
+            expected
+        );
+    });
+
+    it("should handle URLs with different hostnames for ModelConfigurationSetup type", () => {
+        const input = "https://custom-api.example.com/v1/modelconfigurations/abc123";
+        const expected = "https://custom-api.example.com/v1/custom/modelconfigurationsetups/abc123";
+
+        expect(convertToUrlToCustomUrl(input, ModelConfigurationType.ModelConfigurationSetup)).toBe(
+            expected
+        );
+    });
+
+    it("should handle URLs with multiple query parameters for ModelConfiguration type", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu&type=test&version=1.0";
+        const expected =
+            "https://api.models.mint.local/v1.8.0/custom/modelconfigurations/26603296-1530-4f95-9655-ef51e44a5d7c?username=mint%40isi.edu&type=test&version=1.0";
+
+        expect(convertToUrlToCustomUrl(input, ModelConfigurationType.ModelConfiguration)).toBe(
+            expected
+        );
+    });
+});
+
+describe("convertApiUrlToW3Id", () => {
+    it("should convert HTTP API URL to W3ID URI", () => {
+        const input =
+            "http://api.models.mint.local/v1.8.0/modelconfigurations/46ce03cf-4e89-4d09-80b4-d34eca18f02e?username=mint@isi.edu";
+        const expected = "https://w3id.org/okn/i/mint/46ce03cf-4e89-4d09-80b4-d34eca18f02e";
+
+        expect(convertApiUrlToW3Id(input)).toBe(expected);
+    });
+
+    it("should convert HTTPS API URL to W3ID URI", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/46ce03cf-4e89-4d09-80b4-d34eca18f02e?username=mint@isi.edu";
+        const expected = "https://w3id.org/okn/i/mint/46ce03cf-4e89-4d09-80b4-d34eca18f02e";
+
+        expect(convertApiUrlToW3Id(input)).toBe(expected);
+    });
+
+    it("should convert URL without query parameters to W3ID URI", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurations/46ce03cf-4e89-4d09-80b4-d34eca18f02e";
+        const expected = "https://w3id.org/okn/i/mint/46ce03cf-4e89-4d09-80b4-d34eca18f02e";
+
+        expect(convertApiUrlToW3Id(input)).toBe(expected);
+    });
+
+    it("should handle URLs with different paths", () => {
+        const input =
+            "https://api.models.mint.local/v1.8.0/modelconfigurationsetups/abc123?param=value";
+        const expected = "https://w3id.org/okn/i/mint/abc123";
+
+        expect(convertApiUrlToW3Id(input)).toBe(expected);
+    });
+});

--- a/src/classes/mint/model-catalog-graphql-adapter.ts
+++ b/src/classes/mint/model-catalog-graphql-adapter.ts
@@ -1,0 +1,55 @@
+import { ModelConfiguration, ModelConfigurationSetup } from "@mintproject/modelcatalog_client/dist";
+import { Model_Insert_Input } from "../graphql/graph_typing";
+
+export const modelConfigurationToGraphQL = (
+    modelConfiguration: ModelConfiguration
+): Model_Insert_Input => {
+    return {
+        id: modelConfiguration.id || "",
+        name: modelConfiguration.label?.[0] || "",
+        description: modelConfiguration.description?.[0] || "",
+        category: modelConfiguration.hasModelCategory?.[0]?.label?.[0] || "",
+        type: modelConfiguration.type?.[0] || "",
+        region_name: modelConfiguration.hasRegion?.[0]?.label?.[0] || "",
+        dimensionality: modelConfiguration.hasDownloadInstructions?.[0] || "",
+        parameter_assignment: modelConfiguration.parameterization?.[0] || "",
+        parameter_assignment_details: modelConfiguration.hasAssumption?.[0] || "",
+        calibration_target_variable: modelConfiguration.hasOutputVariable?.[0]?.id || "",
+        spatial_grid_type: modelConfiguration.hasGrid?.[0]?.label?.[0] || "",
+        spatial_grid_resolution: modelConfiguration.hasGrid?.[0]?.label?.[0] || "",
+        usage_notes: modelConfiguration.hasUsageNotes?.[0] || "",
+        code_url: modelConfiguration.hasComponentLocation?.[0] || "",
+        output_time_interval: modelConfiguration.hasOutputTimeInterval?.[0]?.id || "",
+        model_configuration: modelConfiguration.id || "",
+        software_image: modelConfiguration.hasSoftwareImage?.[0]?.label?.[0] || "",
+        model_version: modelConfiguration.hasVersion?.[0]?.id || "",
+        model_name: ""
+    };
+};
+
+export const modelConfigurationSetupToGraphQL = (
+    modelConfigurationSetup: ModelConfigurationSetup
+): Model_Insert_Input => {
+    return {
+        id: modelConfigurationSetup.id || "",
+        name: modelConfigurationSetup.label?.[0] || "",
+        description: modelConfigurationSetup.description?.[0] || "",
+        category: modelConfigurationSetup.hasModelCategory?.[0]?.label?.[0] || "",
+        type: modelConfigurationSetup.type?.[0] || "",
+        region_name: modelConfigurationSetup.hasRegion?.[0]?.label?.[0] || "",
+        dimensionality: modelConfigurationSetup.hasDownloadInstructions?.[0] || "",
+        parameter_assignment: modelConfigurationSetup.parameterization?.[0] || "",
+        parameter_assignment_details: modelConfigurationSetup.hasAssumption?.[0] || "",
+        calibration_target_variable: modelConfigurationSetup.hasOutputVariable?.[0]?.id || "",
+        spatial_grid_type: modelConfigurationSetup.hasGrid?.[0]?.label?.[0] || "",
+        spatial_grid_resolution: modelConfigurationSetup.hasGrid?.[0]?.label?.[0] || "",
+        usage_notes: modelConfigurationSetup.hasUsageNotes?.[0] || "",
+        code_url: modelConfigurationSetup.hasComponentLocation?.[0] || "",
+        output_time_interval: modelConfigurationSetup.hasOutputTimeInterval?.[0]?.id || "",
+        // model_configuration: modelConfigurationSetup.id || "",
+        software_image: modelConfigurationSetup.hasSoftwareImage?.[0]?.label?.[0] || "",
+        model_version: modelConfigurationSetup.hasVersion?.[0]?.id || "",
+        model_name: "",
+        model_configuration: ""
+    };
+};


### PR DESCRIPTION
- Updated the subTasksService to directly use model IDs when setting thread models, improving efficiency and clarity.
- Removed unnecessary fetching of model configurations, streamlining the process of adding models to subtasks.
