### PR TITLE
feat: add SubmitSubtaskRequest schema and submit subtask endpoint

### DIFF
--- a/src/api/api-doc.ts
+++ b/src/api/api-doc.ts
@@ -19,6 +19,18 @@ const MintSchema = {
             }
         }
     },
+    SubmitSubtaskRequest: {
+        type: "object",
+        properties: {
+            model_id: {
+                type: "string",
+                description:
+                    "The model id to use format https://w3id.org/okn/i/mint/c07a6f98-6339-4033-84b0-6cd7daca6284",
+                example: "https://w3id.org/okn/i/mint/c07a6f98-6339-4033-84b0-6cd7daca6284",
+                required: true
+            }
+        }
+    },
     AddDataRequest: {
         type: "object",
         properties: {


### PR DESCRIPTION
- Introduced a new SubmitSubtaskRequest schema in the API documentation to define the structure for submitting subtasks, including model ID requirements.
- Implemented a POST endpoint in the subtasks router for submitting a subtask, enhancing the API's functionality for task execution.
- Updated the subTasksService to include logic for handling subtask submissions, improving execution management capabilities.
- Enhanced error handling for authorization and subtask retrieval in the new endpoint, ensuring robust API behavior.