### PR TITLE
feat(schema): add input can be optional on model configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: build image amd64
 on:
     push:
         branches:
-            - "*"
+            - "**"
         tags:
             - "*"
     pull_request:

--- a/src/api/api-v1/paths/problemStatements/tasks/subtasks/executions/index.ts
+++ b/src/api/api-v1/paths/problemStatements/tasks/subtasks/executions/index.ts
@@ -110,7 +110,12 @@ export const executionsRouter = (): Router => {
                                 // Map data bindings to execution bindings format
                                 const bindings: { [input: string]: string } = {};
                                 if (threadModel.data_bindings) {
-                                    for (const binding of threadModel.data_bindings) {
+                                    // Query aliases modelcatalog_dataset_specification as
+                                    // model_io; codegen schema type does not carry the alias.
+                                    for (const binding of threadModel.data_bindings as Array<{
+                                        model_io?: { name?: string | null } | null;
+                                        dataslice_id?: string | null;
+                                    }>) {
                                         if (binding.model_io?.name && binding.dataslice_id) {
                                             bindings[binding.model_io.name] = binding.dataslice_id;
                                         }

--- a/src/classes/graphql/graphql.ts
+++ b/src/classes/graphql/graphql.ts
@@ -922,7 +922,6 @@ export type Execution = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id: Scalars['uuid']['output'];
-  model_id?: Maybe<Scalars['String']['output']>;
   /** An object relationship */
   modelcatalog_configuration?: Maybe<Modelcatalog_Configuration>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
@@ -1096,7 +1095,6 @@ export type Execution_Bool_Exp = {
   end_time?: InputMaybe<Timestamp_Comparison_Exp>;
   execution_engine?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_id?: InputMaybe<String_Comparison_Exp>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Bool_Exp>;
   modelcatalog_configuration_id?: InputMaybe<String_Comparison_Exp>;
   parameter_bindings?: InputMaybe<Execution_Parameter_Binding_Bool_Exp>;
@@ -1121,7 +1119,7 @@ export type Execution_Data_Binding = {
   execution: Execution;
   execution_id: Scalars['uuid']['output'];
   /** An object relationship */
-  model_io: Model_Io;
+  model_io: Modelcatalog_Dataset_Specification;
   model_io_id: Scalars['String']['output'];
   /** An object relationship */
   resource: Resource;
@@ -1171,7 +1169,7 @@ export type Execution_Data_Binding_Bool_Exp = {
   _or?: InputMaybe<Array<Execution_Data_Binding_Bool_Exp>>;
   execution?: InputMaybe<Execution_Bool_Exp>;
   execution_id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_io?: InputMaybe<Model_Io_Bool_Exp>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
   resource?: InputMaybe<Resource_Bool_Exp>;
   resource_id?: InputMaybe<String_Comparison_Exp>;
@@ -1187,7 +1185,7 @@ export enum Execution_Data_Binding_Constraint {
 export type Execution_Data_Binding_Insert_Input = {
   execution?: InputMaybe<Execution_Obj_Rel_Insert_Input>;
   execution_id?: InputMaybe<Scalars['uuid']['input']>;
-  model_io?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
   resource?: InputMaybe<Resource_Obj_Rel_Insert_Input>;
   resource_id?: InputMaybe<Scalars['String']['input']>;
@@ -1243,7 +1241,7 @@ export type Execution_Data_Binding_On_Conflict = {
 export type Execution_Data_Binding_Order_By = {
   execution?: InputMaybe<Execution_Order_By>;
   execution_id?: InputMaybe<Order_By>;
-  model_io?: InputMaybe<Model_Io_Order_By>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   model_io_id?: InputMaybe<Order_By>;
   resource?: InputMaybe<Resource_Order_By>;
   resource_id?: InputMaybe<Order_By>;
@@ -1300,7 +1298,6 @@ export type Execution_Insert_Input = {
   end_time?: InputMaybe<Scalars['timestamp']['input']>;
   execution_engine?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
-  model_id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Obj_Rel_Insert_Input>;
   modelcatalog_configuration_id?: InputMaybe<Scalars['String']['input']>;
   parameter_bindings?: InputMaybe<Execution_Parameter_Binding_Arr_Rel_Insert_Input>;
@@ -1318,7 +1315,6 @@ export type Execution_Max_Fields = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
-  model_id?: Maybe<Scalars['String']['output']>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
   run_id?: Maybe<Scalars['String']['output']>;
   run_progress?: Maybe<Scalars['float8']['output']>;
@@ -1331,7 +1327,6 @@ export type Execution_Max_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   run_id?: InputMaybe<Order_By>;
   run_progress?: InputMaybe<Order_By>;
@@ -1345,7 +1340,6 @@ export type Execution_Min_Fields = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
-  model_id?: Maybe<Scalars['String']['output']>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
   run_id?: Maybe<Scalars['String']['output']>;
   run_progress?: Maybe<Scalars['float8']['output']>;
@@ -1358,7 +1352,6 @@ export type Execution_Min_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   run_id?: InputMaybe<Order_By>;
   run_progress?: InputMaybe<Order_By>;
@@ -1395,7 +1388,6 @@ export type Execution_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   parameter_bindings_aggregate?: InputMaybe<Execution_Parameter_Binding_Aggregate_Order_By>;
@@ -1589,7 +1581,7 @@ export type Execution_Result = {
   execution_id: Scalars['uuid']['output'];
   model_io_id: Scalars['String']['output'];
   /** An object relationship */
-  model_output: Model_Io;
+  model_output: Modelcatalog_Dataset_Specification;
   /** An object relationship */
   resource: Resource;
   resource_id: Scalars['String']['output'];
@@ -1639,7 +1631,7 @@ export type Execution_Result_Bool_Exp = {
   execution?: InputMaybe<Execution_Bool_Exp>;
   execution_id?: InputMaybe<Uuid_Comparison_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
-  model_output?: InputMaybe<Model_Io_Bool_Exp>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   resource?: InputMaybe<Resource_Bool_Exp>;
   resource_id?: InputMaybe<String_Comparison_Exp>;
 };
@@ -1655,7 +1647,7 @@ export type Execution_Result_Insert_Input = {
   execution?: InputMaybe<Execution_Obj_Rel_Insert_Input>;
   execution_id?: InputMaybe<Scalars['uuid']['input']>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
-  model_output?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   resource?: InputMaybe<Resource_Obj_Rel_Insert_Input>;
   resource_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1711,7 +1703,7 @@ export type Execution_Result_Order_By = {
   execution?: InputMaybe<Execution_Order_By>;
   execution_id?: InputMaybe<Order_By>;
   model_io_id?: InputMaybe<Order_By>;
-  model_output?: InputMaybe<Model_Io_Order_By>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   resource?: InputMaybe<Resource_Order_By>;
   resource_id?: InputMaybe<Order_By>;
 };
@@ -1765,8 +1757,6 @@ export enum Execution_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  ModelId = 'model_id',
-  /** column name */
   ModelcatalogConfigurationId = 'modelcatalog_configuration_id',
   /** column name */
   RunId = 'run_id',
@@ -1783,7 +1773,6 @@ export type Execution_Set_Input = {
   end_time?: InputMaybe<Scalars['timestamp']['input']>;
   execution_engine?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
-  model_id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_configuration_id?: InputMaybe<Scalars['String']['input']>;
   run_id?: InputMaybe<Scalars['String']['input']>;
   run_progress?: InputMaybe<Scalars['float8']['input']>;
@@ -1843,8 +1832,6 @@ export enum Execution_Update_Column {
   ExecutionEngine = 'execution_engine',
   /** column name */
   Id = 'id',
-  /** column name */
-  ModelId = 'model_id',
   /** column name */
   ModelcatalogConfigurationId = 'modelcatalog_configuration_id',
   /** column name */
@@ -2306,14 +2293,6 @@ export type Model_Io = {
   __typename?: 'model_io';
   description?: Maybe<Scalars['String']['output']>;
   /** An array relationship */
-  execution_data_bindings: Array<Execution_Data_Binding>;
-  /** An aggregate relationship */
-  execution_data_bindings_aggregate: Execution_Data_Binding_Aggregate;
-  /** An array relationship */
-  execution_results: Array<Execution_Result>;
-  /** An aggregate relationship */
-  execution_results_aggregate: Execution_Result_Aggregate;
-  /** An array relationship */
   fixed_bindings: Array<Model_Input_Fixed_Binding>;
   /** An aggregate relationship */
   fixed_bindings_aggregate: Model_Input_Fixed_Binding_Aggregate;
@@ -2323,55 +2302,11 @@ export type Model_Io = {
   modelcatalog_dataset_specification?: Maybe<Modelcatalog_Dataset_Specification>;
   modelcatalog_dataset_specification_id?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
-  /** An array relationship */
-  thread_model_ios: Array<Thread_Model_Io>;
-  /** An aggregate relationship */
-  thread_model_ios_aggregate: Thread_Model_Io_Aggregate;
   type?: Maybe<Scalars['String']['output']>;
   /** An array relationship */
   variables: Array<Model_Io_Variable>;
   /** An aggregate relationship */
   variables_aggregate: Model_Io_Variable_Aggregate;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Data_BindingsArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Data_Binding_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Data_Binding_Order_By>>;
-  where?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Data_Bindings_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Data_Binding_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Data_Binding_Order_By>>;
-  where?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_ResultsArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Result_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Result_Order_By>>;
-  where?: InputMaybe<Execution_Result_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Results_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Result_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Result_Order_By>>;
-  where?: InputMaybe<Execution_Result_Bool_Exp>;
 };
 
 
@@ -2392,26 +2327,6 @@ export type Model_IoFixed_Bindings_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Model_Input_Fixed_Binding_Order_By>>;
   where?: InputMaybe<Model_Input_Fixed_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoThread_Model_IosArgs = {
-  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
-  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoThread_Model_Ios_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
-  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
 };
 
 
@@ -2476,15 +2391,12 @@ export type Model_Io_Bool_Exp = {
   _not?: InputMaybe<Model_Io_Bool_Exp>;
   _or?: InputMaybe<Array<Model_Io_Bool_Exp>>;
   description?: InputMaybe<String_Comparison_Exp>;
-  execution_data_bindings?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-  execution_results?: InputMaybe<Execution_Result_Bool_Exp>;
   fixed_bindings?: InputMaybe<Model_Input_Fixed_Binding_Bool_Exp>;
   format?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   modelcatalog_dataset_specification_id?: InputMaybe<String_Comparison_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
-  thread_model_ios?: InputMaybe<Thread_Model_Io_Bool_Exp>;
   type?: InputMaybe<String_Comparison_Exp>;
   variables?: InputMaybe<Model_Io_Variable_Bool_Exp>;
 };
@@ -2498,15 +2410,12 @@ export enum Model_Io_Constraint {
 /** input type for inserting data into table "model_io" */
 export type Model_Io_Insert_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
-  execution_data_bindings?: InputMaybe<Execution_Data_Binding_Arr_Rel_Insert_Input>;
-  execution_results?: InputMaybe<Execution_Result_Arr_Rel_Insert_Input>;
   fixed_bindings?: InputMaybe<Model_Input_Fixed_Binding_Arr_Rel_Insert_Input>;
   format?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   modelcatalog_dataset_specification_id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  thread_model_ios?: InputMaybe<Thread_Model_Io_Arr_Rel_Insert_Input>;
   type?: InputMaybe<Scalars['String']['input']>;
   variables?: InputMaybe<Model_Io_Variable_Arr_Rel_Insert_Input>;
 };
@@ -2579,15 +2488,12 @@ export type Model_Io_On_Conflict = {
 /** Ordering options when selecting data from "model_io". */
 export type Model_Io_Order_By = {
   description?: InputMaybe<Order_By>;
-  execution_data_bindings_aggregate?: InputMaybe<Execution_Data_Binding_Aggregate_Order_By>;
-  execution_results_aggregate?: InputMaybe<Execution_Result_Aggregate_Order_By>;
   fixed_bindings_aggregate?: InputMaybe<Model_Input_Fixed_Binding_Aggregate_Order_By>;
   format?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   modelcatalog_dataset_specification_id?: InputMaybe<Order_By>;
   name?: InputMaybe<Order_By>;
-  thread_model_ios_aggregate?: InputMaybe<Thread_Model_Io_Aggregate_Order_By>;
   type?: InputMaybe<Order_By>;
   variables_aggregate?: InputMaybe<Model_Io_Variable_Aggregate_Order_By>;
 };
@@ -4192,6 +4098,7 @@ export type Modelcatalog_Configuration_Input = {
   /** An object relationship */
   input: Modelcatalog_Dataset_Specification;
   input_id: Scalars['String']['output'];
+  is_optional: Scalars['Boolean']['output'];
 };
 
 /** aggregated selection of "modelcatalog_configuration_input" */
@@ -4239,6 +4146,7 @@ export type Modelcatalog_Configuration_Input_Bool_Exp = {
   configuration_id?: InputMaybe<String_Comparison_Exp>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   input_id?: InputMaybe<String_Comparison_Exp>;
+  is_optional?: InputMaybe<Boolean_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "modelcatalog_configuration_input" */
@@ -4253,6 +4161,7 @@ export type Modelcatalog_Configuration_Input_Insert_Input = {
   configuration_id?: InputMaybe<Scalars['String']['input']>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   input_id?: InputMaybe<Scalars['String']['input']>;
+  is_optional?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** aggregate max on columns */
@@ -4303,6 +4212,7 @@ export type Modelcatalog_Configuration_Input_Order_By = {
   configuration_id?: InputMaybe<Order_By>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   input_id?: InputMaybe<Order_By>;
+  is_optional?: InputMaybe<Order_By>;
 };
 
 /** primary key columns input for table: modelcatalog_configuration_input */
@@ -4316,13 +4226,16 @@ export enum Modelcatalog_Configuration_Input_Select_Column {
   /** column name */
   ConfigurationId = 'configuration_id',
   /** column name */
-  InputId = 'input_id'
+  InputId = 'input_id',
+  /** column name */
+  IsOptional = 'is_optional'
 }
 
 /** input type for updating data in table "modelcatalog_configuration_input" */
 export type Modelcatalog_Configuration_Input_Set_Input = {
   configuration_id?: InputMaybe<Scalars['String']['input']>;
   input_id?: InputMaybe<Scalars['String']['input']>;
+  is_optional?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** update columns of table "modelcatalog_configuration_input" */
@@ -4330,7 +4243,9 @@ export enum Modelcatalog_Configuration_Input_Update_Column {
   /** column name */
   ConfigurationId = 'configuration_id',
   /** column name */
-  InputId = 'input_id'
+  InputId = 'input_id',
+  /** column name */
+  IsOptional = 'is_optional'
 }
 
 export type Modelcatalog_Configuration_Input_Updates = {
@@ -5279,6 +5194,10 @@ export type Modelcatalog_Dataset_Specification = {
   presentations: Array<Modelcatalog_Dataset_Specification_Presentation>;
   /** An aggregate relationship */
   presentations_aggregate: Modelcatalog_Dataset_Specification_Presentation_Aggregate;
+  /** An array relationship */
+  thread_model_ios: Array<Thread_Model_Io>;
+  /** An aggregate relationship */
+  thread_model_ios_aggregate: Thread_Model_Io_Aggregate;
 };
 
 
@@ -5361,6 +5280,26 @@ export type Modelcatalog_Dataset_SpecificationPresentations_AggregateArgs = {
   where?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Bool_Exp>;
 };
 
+
+/** columns and relationships of "modelcatalog_dataset_specification" */
+export type Modelcatalog_Dataset_SpecificationThread_Model_IosArgs = {
+  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
+  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
+};
+
+
+/** columns and relationships of "modelcatalog_dataset_specification" */
+export type Modelcatalog_Dataset_SpecificationThread_Model_Ios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
+  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
+};
+
 /** aggregated selection of "modelcatalog_dataset_specification" */
 export type Modelcatalog_Dataset_Specification_Aggregate = {
   __typename?: 'modelcatalog_dataset_specification_aggregate';
@@ -5413,6 +5352,7 @@ export type Modelcatalog_Dataset_Specification_Bool_Exp = {
   model_ios?: InputMaybe<Model_Io_Bool_Exp>;
   position?: InputMaybe<Int_Comparison_Exp>;
   presentations?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Bool_Exp>;
+  thread_model_ios?: InputMaybe<Thread_Model_Io_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "modelcatalog_dataset_specification" */
@@ -5439,6 +5379,7 @@ export type Modelcatalog_Dataset_Specification_Insert_Input = {
   model_ios?: InputMaybe<Model_Io_Arr_Rel_Insert_Input>;
   position?: InputMaybe<Scalars['Int']['input']>;
   presentations?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Arr_Rel_Insert_Input>;
+  thread_model_ios?: InputMaybe<Thread_Model_Io_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -5498,6 +5439,7 @@ export type Modelcatalog_Dataset_Specification_Order_By = {
   model_ios_aggregate?: InputMaybe<Model_Io_Aggregate_Order_By>;
   position?: InputMaybe<Order_By>;
   presentations_aggregate?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Aggregate_Order_By>;
+  thread_model_ios_aggregate?: InputMaybe<Thread_Model_Io_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: modelcatalog_dataset_specification */
@@ -24738,9 +24680,9 @@ export type Thread_Model_Io = {
   /** An object relationship */
   dataslice: Dataslice;
   dataslice_id: Scalars['uuid']['output'];
-  /** An object relationship */
-  model_io: Model_Io;
   model_io_id: Scalars['String']['output'];
+  /** An object relationship */
+  modelcatalog_dataset_specification: Modelcatalog_Dataset_Specification;
   /** An object relationship */
   thread_model: Thread_Model;
   thread_model_id: Scalars['uuid']['output'];
@@ -24789,8 +24731,8 @@ export type Thread_Model_Io_Bool_Exp = {
   _or?: InputMaybe<Array<Thread_Model_Io_Bool_Exp>>;
   dataslice?: InputMaybe<Dataslice_Bool_Exp>;
   dataslice_id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_io?: InputMaybe<Model_Io_Bool_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   thread_model?: InputMaybe<Thread_Model_Bool_Exp>;
   thread_model_id?: InputMaybe<Uuid_Comparison_Exp>;
 };
@@ -24805,8 +24747,8 @@ export enum Thread_Model_Io_Constraint {
 export type Thread_Model_Io_Insert_Input = {
   dataslice?: InputMaybe<Dataslice_Obj_Rel_Insert_Input>;
   dataslice_id?: InputMaybe<Scalars['uuid']['input']>;
-  model_io?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   thread_model?: InputMaybe<Thread_Model_Obj_Rel_Insert_Input>;
   thread_model_id?: InputMaybe<Scalars['uuid']['input']>;
 };
@@ -24861,8 +24803,8 @@ export type Thread_Model_Io_On_Conflict = {
 export type Thread_Model_Io_Order_By = {
   dataslice?: InputMaybe<Dataslice_Order_By>;
   dataslice_id?: InputMaybe<Order_By>;
-  model_io?: InputMaybe<Model_Io_Order_By>;
   model_io_id?: InputMaybe<Order_By>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   thread_model?: InputMaybe<Thread_Model_Order_By>;
   thread_model_id?: InputMaybe<Order_By>;
 };

--- a/src/classes/graphql/graphql_adapter.test.ts
+++ b/src/classes/graphql/graphql_adapter.test.ts
@@ -1,4 +1,4 @@
-import { executionToGQL, executionFromGQL } from "@/classes/graphql/graphql_adapter";
+import { executionToGQL, executionFromGQL, modelIOFromCatalogGQL } from "@/classes/graphql/graphql_adapter";
 import { Execution } from "@/classes/mint/mint-types";
 
 const makeExecution = (overrides: Partial<Execution> = {}): Execution => ({
@@ -35,6 +35,26 @@ describe("executionToGQL", () => {
         expect(result.execution_engine).toBe("tapis");
         expect(result.run_id).toBe("run-xyz");
         expect(result.id).toBe("exec-001");
+    });
+});
+
+describe("modelIOFromCatalogGQL", () => {
+    it("reads is_optional=true from junction row", () => {
+        const row = {
+            input: { id: "ds-1", label: "DS One", has_format: "", position: 1 },
+            is_optional: true
+        };
+        const result = modelIOFromCatalogGQL(row);
+        expect(result.is_optional).toBe(true);
+        expect(result.id).toBe("ds-1");
+    });
+
+    it("defaults is_optional to false when absent from junction row", () => {
+        const row = {
+            input: { id: "ds-2", label: "DS Two", has_format: "", position: 2 }
+        };
+        const result = modelIOFromCatalogGQL(row);
+        expect(result.is_optional).toBe(false);
     });
 });
 

--- a/src/classes/graphql/graphql_adapter.ts
+++ b/src/classes/graphql/graphql_adapter.ts
@@ -487,17 +487,20 @@ export const modelFromGQL = (config: any): Model => {
         model_configuration: config.model_configuration_id || null,
         software_image: config.has_software_image || "",
         code_url: config.has_component_location || "",
-        input_files: (config.inputs || []).map((row: any) => modelIOFromCatalogGQL(row.input)),
-        output_files: (config.outputs || []).map((row: any) => modelIOFromCatalogGQL(row.output)),
+        input_files: (config.inputs || []).map((row: any) => modelIOFromCatalogGQL(row)),
+        output_files: (config.outputs || []).map((row: any) => modelIOFromCatalogGQL(row, 'output')),
         input_parameters: (config.parameters || []).map((row: any) =>
             modelParameterFromCatalogGQL(row.parameter)
         )
     } as Model;
 };
 
-// Maps a catalog input/output from the unified modelcatalog_configuration junction shape
-// (no nested model_io wrapper; flat fields from modelcatalog_dataset_specification)
-export const modelIOFromCatalogGQL = (io: any): ModelIO => {
+// Maps a catalog input/output junction row.
+// junctionRow has shape { input: {...}, is_optional: boolean } for inputs,
+// or { output: {...} } for outputs (is_optional not present on output junction).
+export const modelIOFromCatalogGQL = (junctionRow: any, entityKey?: string): ModelIO => {
+    const key = entityKey ?? 'input';
+    const io = junctionRow[key] ?? junctionRow;
     return {
         id: io.id,
         name: io.label || io.id,
@@ -505,7 +508,8 @@ export const modelIOFromCatalogGQL = (io: any): ModelIO => {
         format: io.has_format || "",
         value: null,
         position: io.position || 0,
-        variables: []
+        variables: [],
+        is_optional: junctionRow.is_optional ?? false,
     } as ModelIO;
 };
 

--- a/src/classes/graphql/queries/fragments/model-info.graphql
+++ b/src/classes/graphql/queries/fragments/model-info.graphql
@@ -6,6 +6,7 @@ fragment model_info on modelcatalog_configuration {
     has_software_image
     model_configuration_id
     inputs {
+        is_optional
         input {
             id
             label

--- a/src/classes/graphql/queries/model/get-modelcatalog-configuration.graphql
+++ b/src/classes/graphql/queries/model/get-modelcatalog-configuration.graphql
@@ -22,6 +22,7 @@ query get_modelcatalog_configuration($id: String!) {
       }
     }
     inputs {
+      is_optional
       input {
         id
         label

--- a/src/classes/graphql/types.ts
+++ b/src/classes/graphql/types.ts
@@ -921,7 +921,6 @@ export type Execution = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id: Scalars['uuid']['output'];
-  model_id?: Maybe<Scalars['String']['output']>;
   /** An object relationship */
   modelcatalog_configuration?: Maybe<Modelcatalog_Configuration>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
@@ -1095,7 +1094,6 @@ export type Execution_Bool_Exp = {
   end_time?: InputMaybe<Timestamp_Comparison_Exp>;
   execution_engine?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_id?: InputMaybe<String_Comparison_Exp>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Bool_Exp>;
   modelcatalog_configuration_id?: InputMaybe<String_Comparison_Exp>;
   parameter_bindings?: InputMaybe<Execution_Parameter_Binding_Bool_Exp>;
@@ -1120,7 +1118,7 @@ export type Execution_Data_Binding = {
   execution: Execution;
   execution_id: Scalars['uuid']['output'];
   /** An object relationship */
-  model_io: Model_Io;
+  model_io: Modelcatalog_Dataset_Specification;
   model_io_id: Scalars['String']['output'];
   /** An object relationship */
   resource: Resource;
@@ -1170,7 +1168,7 @@ export type Execution_Data_Binding_Bool_Exp = {
   _or?: InputMaybe<Array<Execution_Data_Binding_Bool_Exp>>;
   execution?: InputMaybe<Execution_Bool_Exp>;
   execution_id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_io?: InputMaybe<Model_Io_Bool_Exp>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
   resource?: InputMaybe<Resource_Bool_Exp>;
   resource_id?: InputMaybe<String_Comparison_Exp>;
@@ -1186,7 +1184,7 @@ export enum Execution_Data_Binding_Constraint {
 export type Execution_Data_Binding_Insert_Input = {
   execution?: InputMaybe<Execution_Obj_Rel_Insert_Input>;
   execution_id?: InputMaybe<Scalars['uuid']['input']>;
-  model_io?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
   resource?: InputMaybe<Resource_Obj_Rel_Insert_Input>;
   resource_id?: InputMaybe<Scalars['String']['input']>;
@@ -1242,7 +1240,7 @@ export type Execution_Data_Binding_On_Conflict = {
 export type Execution_Data_Binding_Order_By = {
   execution?: InputMaybe<Execution_Order_By>;
   execution_id?: InputMaybe<Order_By>;
-  model_io?: InputMaybe<Model_Io_Order_By>;
+  model_io?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   model_io_id?: InputMaybe<Order_By>;
   resource?: InputMaybe<Resource_Order_By>;
   resource_id?: InputMaybe<Order_By>;
@@ -1299,7 +1297,6 @@ export type Execution_Insert_Input = {
   end_time?: InputMaybe<Scalars['timestamp']['input']>;
   execution_engine?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
-  model_id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Obj_Rel_Insert_Input>;
   modelcatalog_configuration_id?: InputMaybe<Scalars['String']['input']>;
   parameter_bindings?: InputMaybe<Execution_Parameter_Binding_Arr_Rel_Insert_Input>;
@@ -1317,7 +1314,6 @@ export type Execution_Max_Fields = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
-  model_id?: Maybe<Scalars['String']['output']>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
   run_id?: Maybe<Scalars['String']['output']>;
   run_progress?: Maybe<Scalars['float8']['output']>;
@@ -1330,7 +1326,6 @@ export type Execution_Max_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   run_id?: InputMaybe<Order_By>;
   run_progress?: InputMaybe<Order_By>;
@@ -1344,7 +1339,6 @@ export type Execution_Min_Fields = {
   end_time?: Maybe<Scalars['timestamp']['output']>;
   execution_engine?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
-  model_id?: Maybe<Scalars['String']['output']>;
   modelcatalog_configuration_id?: Maybe<Scalars['String']['output']>;
   run_id?: Maybe<Scalars['String']['output']>;
   run_progress?: Maybe<Scalars['float8']['output']>;
@@ -1357,7 +1351,6 @@ export type Execution_Min_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   run_id?: InputMaybe<Order_By>;
   run_progress?: InputMaybe<Order_By>;
@@ -1394,7 +1387,6 @@ export type Execution_Order_By = {
   end_time?: InputMaybe<Order_By>;
   execution_engine?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
-  model_id?: InputMaybe<Order_By>;
   modelcatalog_configuration?: InputMaybe<Modelcatalog_Configuration_Order_By>;
   modelcatalog_configuration_id?: InputMaybe<Order_By>;
   parameter_bindings_aggregate?: InputMaybe<Execution_Parameter_Binding_Aggregate_Order_By>;
@@ -1588,7 +1580,7 @@ export type Execution_Result = {
   execution_id: Scalars['uuid']['output'];
   model_io_id: Scalars['String']['output'];
   /** An object relationship */
-  model_output: Model_Io;
+  model_output: Modelcatalog_Dataset_Specification;
   /** An object relationship */
   resource: Resource;
   resource_id: Scalars['String']['output'];
@@ -1638,7 +1630,7 @@ export type Execution_Result_Bool_Exp = {
   execution?: InputMaybe<Execution_Bool_Exp>;
   execution_id?: InputMaybe<Uuid_Comparison_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
-  model_output?: InputMaybe<Model_Io_Bool_Exp>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   resource?: InputMaybe<Resource_Bool_Exp>;
   resource_id?: InputMaybe<String_Comparison_Exp>;
 };
@@ -1654,7 +1646,7 @@ export type Execution_Result_Insert_Input = {
   execution?: InputMaybe<Execution_Obj_Rel_Insert_Input>;
   execution_id?: InputMaybe<Scalars['uuid']['input']>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
-  model_output?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   resource?: InputMaybe<Resource_Obj_Rel_Insert_Input>;
   resource_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1710,7 +1702,7 @@ export type Execution_Result_Order_By = {
   execution?: InputMaybe<Execution_Order_By>;
   execution_id?: InputMaybe<Order_By>;
   model_io_id?: InputMaybe<Order_By>;
-  model_output?: InputMaybe<Model_Io_Order_By>;
+  model_output?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   resource?: InputMaybe<Resource_Order_By>;
   resource_id?: InputMaybe<Order_By>;
 };
@@ -1764,8 +1756,6 @@ export enum Execution_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  ModelId = 'model_id',
-  /** column name */
   ModelcatalogConfigurationId = 'modelcatalog_configuration_id',
   /** column name */
   RunId = 'run_id',
@@ -1782,7 +1772,6 @@ export type Execution_Set_Input = {
   end_time?: InputMaybe<Scalars['timestamp']['input']>;
   execution_engine?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['uuid']['input']>;
-  model_id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_configuration_id?: InputMaybe<Scalars['String']['input']>;
   run_id?: InputMaybe<Scalars['String']['input']>;
   run_progress?: InputMaybe<Scalars['float8']['input']>;
@@ -1842,8 +1831,6 @@ export enum Execution_Update_Column {
   ExecutionEngine = 'execution_engine',
   /** column name */
   Id = 'id',
-  /** column name */
-  ModelId = 'model_id',
   /** column name */
   ModelcatalogConfigurationId = 'modelcatalog_configuration_id',
   /** column name */
@@ -2305,14 +2292,6 @@ export type Model_Io = {
   __typename?: 'model_io';
   description?: Maybe<Scalars['String']['output']>;
   /** An array relationship */
-  execution_data_bindings: Array<Execution_Data_Binding>;
-  /** An aggregate relationship */
-  execution_data_bindings_aggregate: Execution_Data_Binding_Aggregate;
-  /** An array relationship */
-  execution_results: Array<Execution_Result>;
-  /** An aggregate relationship */
-  execution_results_aggregate: Execution_Result_Aggregate;
-  /** An array relationship */
   fixed_bindings: Array<Model_Input_Fixed_Binding>;
   /** An aggregate relationship */
   fixed_bindings_aggregate: Model_Input_Fixed_Binding_Aggregate;
@@ -2322,55 +2301,11 @@ export type Model_Io = {
   modelcatalog_dataset_specification?: Maybe<Modelcatalog_Dataset_Specification>;
   modelcatalog_dataset_specification_id?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
-  /** An array relationship */
-  thread_model_ios: Array<Thread_Model_Io>;
-  /** An aggregate relationship */
-  thread_model_ios_aggregate: Thread_Model_Io_Aggregate;
   type?: Maybe<Scalars['String']['output']>;
   /** An array relationship */
   variables: Array<Model_Io_Variable>;
   /** An aggregate relationship */
   variables_aggregate: Model_Io_Variable_Aggregate;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Data_BindingsArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Data_Binding_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Data_Binding_Order_By>>;
-  where?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Data_Bindings_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Data_Binding_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Data_Binding_Order_By>>;
-  where?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_ResultsArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Result_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Result_Order_By>>;
-  where?: InputMaybe<Execution_Result_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoExecution_Results_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Execution_Result_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Execution_Result_Order_By>>;
-  where?: InputMaybe<Execution_Result_Bool_Exp>;
 };
 
 
@@ -2391,26 +2326,6 @@ export type Model_IoFixed_Bindings_AggregateArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   order_by?: InputMaybe<Array<Model_Input_Fixed_Binding_Order_By>>;
   where?: InputMaybe<Model_Input_Fixed_Binding_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoThread_Model_IosArgs = {
-  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
-  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
-};
-
-
-/** columns and relationships of "model_io" */
-export type Model_IoThread_Model_Ios_AggregateArgs = {
-  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
-  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
 };
 
 
@@ -2475,15 +2390,12 @@ export type Model_Io_Bool_Exp = {
   _not?: InputMaybe<Model_Io_Bool_Exp>;
   _or?: InputMaybe<Array<Model_Io_Bool_Exp>>;
   description?: InputMaybe<String_Comparison_Exp>;
-  execution_data_bindings?: InputMaybe<Execution_Data_Binding_Bool_Exp>;
-  execution_results?: InputMaybe<Execution_Result_Bool_Exp>;
   fixed_bindings?: InputMaybe<Model_Input_Fixed_Binding_Bool_Exp>;
   format?: InputMaybe<String_Comparison_Exp>;
   id?: InputMaybe<String_Comparison_Exp>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   modelcatalog_dataset_specification_id?: InputMaybe<String_Comparison_Exp>;
   name?: InputMaybe<String_Comparison_Exp>;
-  thread_model_ios?: InputMaybe<Thread_Model_Io_Bool_Exp>;
   type?: InputMaybe<String_Comparison_Exp>;
   variables?: InputMaybe<Model_Io_Variable_Bool_Exp>;
 };
@@ -2497,15 +2409,12 @@ export enum Model_Io_Constraint {
 /** input type for inserting data into table "model_io" */
 export type Model_Io_Insert_Input = {
   description?: InputMaybe<Scalars['String']['input']>;
-  execution_data_bindings?: InputMaybe<Execution_Data_Binding_Arr_Rel_Insert_Input>;
-  execution_results?: InputMaybe<Execution_Result_Arr_Rel_Insert_Input>;
   fixed_bindings?: InputMaybe<Model_Input_Fixed_Binding_Arr_Rel_Insert_Input>;
   format?: InputMaybe<Scalars['String']['input']>;
   id?: InputMaybe<Scalars['String']['input']>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   modelcatalog_dataset_specification_id?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
-  thread_model_ios?: InputMaybe<Thread_Model_Io_Arr_Rel_Insert_Input>;
   type?: InputMaybe<Scalars['String']['input']>;
   variables?: InputMaybe<Model_Io_Variable_Arr_Rel_Insert_Input>;
 };
@@ -2578,15 +2487,12 @@ export type Model_Io_On_Conflict = {
 /** Ordering options when selecting data from "model_io". */
 export type Model_Io_Order_By = {
   description?: InputMaybe<Order_By>;
-  execution_data_bindings_aggregate?: InputMaybe<Execution_Data_Binding_Aggregate_Order_By>;
-  execution_results_aggregate?: InputMaybe<Execution_Result_Aggregate_Order_By>;
   fixed_bindings_aggregate?: InputMaybe<Model_Input_Fixed_Binding_Aggregate_Order_By>;
   format?: InputMaybe<Order_By>;
   id?: InputMaybe<Order_By>;
   modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   modelcatalog_dataset_specification_id?: InputMaybe<Order_By>;
   name?: InputMaybe<Order_By>;
-  thread_model_ios_aggregate?: InputMaybe<Thread_Model_Io_Aggregate_Order_By>;
   type?: InputMaybe<Order_By>;
   variables_aggregate?: InputMaybe<Model_Io_Variable_Aggregate_Order_By>;
 };
@@ -4191,6 +4097,7 @@ export type Modelcatalog_Configuration_Input = {
   /** An object relationship */
   input: Modelcatalog_Dataset_Specification;
   input_id: Scalars['String']['output'];
+  is_optional: Scalars['Boolean']['output'];
 };
 
 /** aggregated selection of "modelcatalog_configuration_input" */
@@ -4238,6 +4145,7 @@ export type Modelcatalog_Configuration_Input_Bool_Exp = {
   configuration_id?: InputMaybe<String_Comparison_Exp>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   input_id?: InputMaybe<String_Comparison_Exp>;
+  is_optional?: InputMaybe<Boolean_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "modelcatalog_configuration_input" */
@@ -4252,6 +4160,7 @@ export type Modelcatalog_Configuration_Input_Insert_Input = {
   configuration_id?: InputMaybe<Scalars['String']['input']>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   input_id?: InputMaybe<Scalars['String']['input']>;
+  is_optional?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** aggregate max on columns */
@@ -4302,6 +4211,7 @@ export type Modelcatalog_Configuration_Input_Order_By = {
   configuration_id?: InputMaybe<Order_By>;
   input?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   input_id?: InputMaybe<Order_By>;
+  is_optional?: InputMaybe<Order_By>;
 };
 
 /** primary key columns input for table: modelcatalog_configuration_input */
@@ -4315,13 +4225,16 @@ export enum Modelcatalog_Configuration_Input_Select_Column {
   /** column name */
   ConfigurationId = 'configuration_id',
   /** column name */
-  InputId = 'input_id'
+  InputId = 'input_id',
+  /** column name */
+  IsOptional = 'is_optional'
 }
 
 /** input type for updating data in table "modelcatalog_configuration_input" */
 export type Modelcatalog_Configuration_Input_Set_Input = {
   configuration_id?: InputMaybe<Scalars['String']['input']>;
   input_id?: InputMaybe<Scalars['String']['input']>;
+  is_optional?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** update columns of table "modelcatalog_configuration_input" */
@@ -4329,7 +4242,9 @@ export enum Modelcatalog_Configuration_Input_Update_Column {
   /** column name */
   ConfigurationId = 'configuration_id',
   /** column name */
-  InputId = 'input_id'
+  InputId = 'input_id',
+  /** column name */
+  IsOptional = 'is_optional'
 }
 
 export type Modelcatalog_Configuration_Input_Updates = {
@@ -5278,6 +5193,10 @@ export type Modelcatalog_Dataset_Specification = {
   presentations: Array<Modelcatalog_Dataset_Specification_Presentation>;
   /** An aggregate relationship */
   presentations_aggregate: Modelcatalog_Dataset_Specification_Presentation_Aggregate;
+  /** An array relationship */
+  thread_model_ios: Array<Thread_Model_Io>;
+  /** An aggregate relationship */
+  thread_model_ios_aggregate: Thread_Model_Io_Aggregate;
 };
 
 
@@ -5360,6 +5279,26 @@ export type Modelcatalog_Dataset_SpecificationPresentations_AggregateArgs = {
   where?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Bool_Exp>;
 };
 
+
+/** columns and relationships of "modelcatalog_dataset_specification" */
+export type Modelcatalog_Dataset_SpecificationThread_Model_IosArgs = {
+  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
+  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
+};
+
+
+/** columns and relationships of "modelcatalog_dataset_specification" */
+export type Modelcatalog_Dataset_SpecificationThread_Model_Ios_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Thread_Model_Io_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Thread_Model_Io_Order_By>>;
+  where?: InputMaybe<Thread_Model_Io_Bool_Exp>;
+};
+
 /** aggregated selection of "modelcatalog_dataset_specification" */
 export type Modelcatalog_Dataset_Specification_Aggregate = {
   __typename?: 'modelcatalog_dataset_specification_aggregate';
@@ -5412,6 +5351,7 @@ export type Modelcatalog_Dataset_Specification_Bool_Exp = {
   model_ios?: InputMaybe<Model_Io_Bool_Exp>;
   position?: InputMaybe<Int_Comparison_Exp>;
   presentations?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Bool_Exp>;
+  thread_model_ios?: InputMaybe<Thread_Model_Io_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "modelcatalog_dataset_specification" */
@@ -5438,6 +5378,7 @@ export type Modelcatalog_Dataset_Specification_Insert_Input = {
   model_ios?: InputMaybe<Model_Io_Arr_Rel_Insert_Input>;
   position?: InputMaybe<Scalars['Int']['input']>;
   presentations?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Arr_Rel_Insert_Input>;
+  thread_model_ios?: InputMaybe<Thread_Model_Io_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -5497,6 +5438,7 @@ export type Modelcatalog_Dataset_Specification_Order_By = {
   model_ios_aggregate?: InputMaybe<Model_Io_Aggregate_Order_By>;
   position?: InputMaybe<Order_By>;
   presentations_aggregate?: InputMaybe<Modelcatalog_Dataset_Specification_Presentation_Aggregate_Order_By>;
+  thread_model_ios_aggregate?: InputMaybe<Thread_Model_Io_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: modelcatalog_dataset_specification */
@@ -24737,9 +24679,9 @@ export type Thread_Model_Io = {
   /** An object relationship */
   dataslice: Dataslice;
   dataslice_id: Scalars['uuid']['output'];
-  /** An object relationship */
-  model_io: Model_Io;
   model_io_id: Scalars['String']['output'];
+  /** An object relationship */
+  modelcatalog_dataset_specification: Modelcatalog_Dataset_Specification;
   /** An object relationship */
   thread_model: Thread_Model;
   thread_model_id: Scalars['uuid']['output'];
@@ -24788,8 +24730,8 @@ export type Thread_Model_Io_Bool_Exp = {
   _or?: InputMaybe<Array<Thread_Model_Io_Bool_Exp>>;
   dataslice?: InputMaybe<Dataslice_Bool_Exp>;
   dataslice_id?: InputMaybe<Uuid_Comparison_Exp>;
-  model_io?: InputMaybe<Model_Io_Bool_Exp>;
   model_io_id?: InputMaybe<String_Comparison_Exp>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Bool_Exp>;
   thread_model?: InputMaybe<Thread_Model_Bool_Exp>;
   thread_model_id?: InputMaybe<Uuid_Comparison_Exp>;
 };
@@ -24804,8 +24746,8 @@ export enum Thread_Model_Io_Constraint {
 export type Thread_Model_Io_Insert_Input = {
   dataslice?: InputMaybe<Dataslice_Obj_Rel_Insert_Input>;
   dataslice_id?: InputMaybe<Scalars['uuid']['input']>;
-  model_io?: InputMaybe<Model_Io_Obj_Rel_Insert_Input>;
   model_io_id?: InputMaybe<Scalars['String']['input']>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Obj_Rel_Insert_Input>;
   thread_model?: InputMaybe<Thread_Model_Obj_Rel_Insert_Input>;
   thread_model_id?: InputMaybe<Scalars['uuid']['input']>;
 };
@@ -24860,8 +24802,8 @@ export type Thread_Model_Io_On_Conflict = {
 export type Thread_Model_Io_Order_By = {
   dataslice?: InputMaybe<Dataslice_Order_By>;
   dataslice_id?: InputMaybe<Order_By>;
-  model_io?: InputMaybe<Model_Io_Order_By>;
   model_io_id?: InputMaybe<Order_By>;
+  modelcatalog_dataset_specification?: InputMaybe<Modelcatalog_Dataset_Specification_Order_By>;
   thread_model?: InputMaybe<Thread_Model_Order_By>;
   thread_model_id?: InputMaybe<Order_By>;
 };

--- a/src/classes/mint/mint-types.ts
+++ b/src/classes/mint/mint-types.ts
@@ -335,6 +335,7 @@ export interface ModelIO extends IdNameObject {
     value?: Dataslice;
     position?: number;
     format?: string;
+    is_optional?: boolean;
 }
 
 export interface ModelOutput {

--- a/src/classes/tapis/adapters/TapisJobService.ts
+++ b/src/classes/tapis/adapters/TapisJobService.ts
@@ -114,6 +114,15 @@ export class TapisJobService {
                 }
 
                 const datasets = seed.datasets[modelInput.id] || [];
+
+                if (datasets.length === 0 && modelInput.is_optional) {
+                    // Skip optional input — no datasets bound, safe to omit from Tapis submission
+                    console.info(
+                        `Skipping optional input ${modelInput.name} — no datasets bound`
+                    );
+                    return [];
+                }
+
                 return datasets.map(
                     (dataset: DataResource) =>
                         ({

--- a/src/classes/tapis/adapters/tests/fixtures/app.ts
+++ b/src/classes/tapis/adapters/tests/fixtures/app.ts
@@ -1,6 +1,6 @@
 import { Apps } from "@tapis/tapis-typescript";
 
-export default {
+const baseApp = {
     id: "modflow-2005",
     version: "0.0.4",
     description: "Run an non-interactive script on TACC using docker.",
@@ -175,5 +175,41 @@ export default {
         icon: "jupyter",
         category: "Data Processing",
         queueFilter: ["development", "normal"]
+    }
+} as Apps.TapisApp;
+
+export default baseApp;
+
+export const appWithOptionalInput: Apps.TapisApp = {
+    ...baseApp,
+    jobAttributes: {
+        ...baseApp.jobAttributes,
+        fileInputs: [
+            {
+                name: "optional_file",
+                description: "An optional supplementary input file",
+                inputMode: "OPTIONAL",
+                autoMountLocal: true,
+                sourceUrl: null,
+                targetPath: "optional.dat"
+            }
+        ]
+    }
+} as Apps.TapisApp;
+
+export const appWithUnknownRequiredInput: Apps.TapisApp = {
+    ...baseApp,
+    jobAttributes: {
+        ...baseApp.jobAttributes,
+        fileInputs: [
+            {
+                name: "unknown_file",
+                description: "A required input file whose name is not registered in model.input_files",
+                inputMode: "REQUIRED",
+                autoMountLocal: true,
+                sourceUrl: null,
+                targetPath: "unknown.dat"
+            }
+        ]
     }
 } as Apps.TapisApp;

--- a/src/classes/tapis/adapters/tests/fixtures/model.ts
+++ b/src/classes/tapis/adapters/tests/fixtures/model.ts
@@ -1,4 +1,6 @@
-export default {
+import { Model } from "@/classes/mint/mint-types";
+
+const baseModel = {
     id: "https://w3id.org/okn/i/mint/modflow_2005_BartonSprings_avg",
     name: "MODFLOW 2005 model setup calibrated for the Barton Springs region. Files for average conditions have been pre-selected",
     description:
@@ -270,3 +272,21 @@ export default {
         }
     ]
 };
+
+export default baseModel;
+
+export const modelWithOptionalInput: Model = {
+    ...(baseModel as unknown as Model),
+    input_files: [
+        {
+            id: "https://w3id.org/okn/i/mint/optional-ds",
+            name: "optional_file",
+            type: "",
+            format: "",
+            value: null,
+            position: 0,
+            variables: [],
+            is_optional: true
+        }
+    ]
+} as unknown as Model;

--- a/src/classes/tapis/adapters/tests/jobs.test.ts
+++ b/src/classes/tapis/adapters/tests/jobs.test.ts
@@ -1,6 +1,6 @@
 import seeds from "./fixtures/seeds";
-import app from "./fixtures/app";
-import model from "./fixtures/model";
+import app, { appWithOptionalInput, appWithUnknownRequiredInput } from "./fixtures/app";
+import model, { modelWithOptionalInput } from "./fixtures/model";
 import jobFileInputsExpected from "./expected/jobFileInputs";
 import { expectedJobParameterSetNonDefault } from "./expected/jobParameterSet";
 import { TapisJobService } from "@/classes/tapis/adapters/TapisJobService";
@@ -16,4 +16,62 @@ test("test create job file inputs from seed", () => {
     const jobParameterSet = jobService.createJobParameterSetFromSeed(seeds[0], app, model);
     expect(jobInputs).toEqual(jobFileInputsExpected);
     expect(jobParameterSet).toEqual(expectedJobParameterSetNonDefault);
+});
+
+const seedWithMissingOptionalInput = {
+    ...seeds[0],
+    datasets: {}
+};
+
+const seedWithOptionalInputBound = {
+    ...seeds[0],
+    datasets: {
+        "https://w3id.org/okn/i/mint/optional-ds": [
+            { id: "ds1", url: "https://example.com/optional.dat", name: "optional.dat", type: "" }
+        ]
+    }
+};
+
+test("optional input with no datasets is skipped", () => {
+    const jobService = new TapisJobService(
+        new Jobs.JobsApi(),
+        new Jobs.SubscriptionsApi(),
+        new Jobs.ShareApi()
+    );
+    const jobInputs = jobService.createJobFileInputsFromSeed(
+        seedWithMissingOptionalInput,
+        appWithOptionalInput,
+        modelWithOptionalInput
+    );
+    expect(jobInputs.find((i) => i.name === "optional_file")).toBeUndefined();
+    expect(jobInputs).toHaveLength(0);
+});
+
+test("throws when app fileInput name is not found in model.input_files", () => {
+    const jobService = new TapisJobService(
+        new Jobs.JobsApi(),
+        new Jobs.SubscriptionsApi(),
+        new Jobs.ShareApi()
+    );
+    expect(() =>
+        jobService.createJobFileInputsFromSeed(
+            { ...seeds[0], datasets: {} },
+            appWithUnknownRequiredInput,
+            model
+        )
+    ).toThrow("Component input not found");
+});
+
+test("optional input with datasets present is included", () => {
+    const jobService = new TapisJobService(
+        new Jobs.JobsApi(),
+        new Jobs.SubscriptionsApi(),
+        new Jobs.ShareApi()
+    );
+    const jobInputs = jobService.createJobFileInputsFromSeed(
+        seedWithOptionalInputBound,
+        appWithOptionalInput,
+        modelWithOptionalInput
+    );
+    expect(jobInputs.find((i) => i.name === "optional_file")).toBeDefined();
 });


### PR DESCRIPTION
## Summary

- Widen docker-publish trigger from `branches: '*'` to `branches: '**'` so slashed branch names (e.g. `gsd/phase-12-is-optional`) actually publish images. Mirrors fixes already applied in [ui e0547dd](https://github.com/mintproject/mint-ui-lit/commit/e0547dd) and [model-catalog-api 7109442](https://github.com/mintproject/model-catalog-api/commit/7109442).
- Cast iterated `thread_model.data_bindings` to a local shape with `model_io` so `executions/index.ts` compiles. Phase 12-03 codegen removed the `model_io: Model_Io` field from `Thread_Model_Io` and replaced it with `modelcatalog_dataset_specification`. The query in `thread/get.graphql` still aliases that relationship as `model_io`, so runtime payload is correct, but the codegen schema type no longer carries the alias.

This bug only surfaced once branch trigger was widened (since the build never ran on slashed feature branches before). docker/metadata-action `type=ref,event=branch` already sanitizes slashes, and the SHA tag is also emitted, so trigger widening alone is sufficient on this repo (no SAFE_BRANCH step needed).

## Verification

- `npx jest src/classes/tapis/adapters/tests/jobs.test.ts -t optional` → both `optional input ... is skipped` and `optional input ... is included` pass.
- Local `NODE_OPTIONS=--openssl-legacy-provider npm run build` compiles clean.
- CI (this branch HEAD): green. Image `mintproject/ensemble-manager:ef84ba3a7d0d7fbb05bd84a1c29636d4cabd5e4e` deployed to dev cluster (helm rev 58, pod healthy on new tag, deployed phase 12-04 TapisJobService skip-when-optional logic).

## Test plan

- [x] CI builds green on slashed branch
- [x] Unit tests: optional-input skip and include paths pass
- [x] Image tag visible in Docker Hub
- [x] helm upgrade rolls out cleanly to dev cluster
- [ ] End-to-end Tapis submission with optional input + no dataslice (requires UI session against dev)