### PR TITLE
fix(tapis): tolerate empty-string parameter bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node:24-alpine
 
 # # Install cwltool
 # RUN apk add --update \

--- a/src/classes/tapis/adapters/TapisExecutionService.ts
+++ b/src/classes/tapis/adapters/TapisExecutionService.ts
@@ -80,6 +80,7 @@ export class TapisExecutionService implements IExecutionService {
         threadId: string,
         threadModelId: string
     ): Promise<SubmissionResult> {
+        this.seeds = [];
         try {
             const app = await this.loadTapisApp(component);
             console.log("Submitting executions", executions);

--- a/src/classes/tapis/helpers.ts
+++ b/src/classes/tapis/helpers.ts
@@ -109,7 +109,7 @@ export function getInputsParameters(model: Model, bindings: InputBindings, regio
             parameters[ip.id] = value.toString();
         }
         // HACK: Replace region geojson
-        if (parameters[ip.id].match(/__region_geojson:(.+)/)) {
+        if (parameters[ip.id]?.match(/__region_geojson:(.+)/)) {
             const region_geojson = _getRegionGeoJson(region);
             parameters[ip.id] = region_geojson;
         }

--- a/src/classes/tapis/tests/helpers.test.ts
+++ b/src/classes/tapis/tests/helpers.test.ts
@@ -1,6 +1,8 @@
 import model from "@/classes/tapis/fixtures/model";
 import bindings from "@/classes/tapis/fixtures/input-bindings";
-import { getInputDatasets } from "@/classes/tapis/helpers";
+import { getInputDatasets, getInputsParameters } from "@/classes/tapis/helpers";
+import { Model, Region } from "@/classes/mint/mint-types";
+
 test("get inputs datasets", () => {
     const key = "https://w3id.org/okn/i/mint/modflow_2005_BartonSprings_avg_Bas";
     const datasets = getInputDatasets(model, bindings);
@@ -13,4 +15,34 @@ test("get inputs datasets", () => {
     expect(datasets[key][0].url).toBe(
         "https://data.mint.isi.edu/files/sample-inputs-outputs/modflowInputs/BARTON_SPRINGS_2001_2010AVERAGE.ba6"
     );
+});
+
+describe("getInputsParameters", () => {
+    const region = { geometries: [] } as unknown as Region;
+    const paramId = "https://w3id.org/okn/i/mint/4103a17f-9927-4c76-824d-753daecd0698";
+
+    const buildModel = (params: unknown[]): Model =>
+        ({ input_parameters: params } as unknown as Model);
+
+    test("does not throw when binding value is empty string and parameter has no default", () => {
+        const m = buildModel([{ id: paramId, type: "string" }]);
+        const empty: Record<string, string> = { [paramId]: "" };
+        expect(() => getInputsParameters(m, empty as never, region)).not.toThrow();
+        const { parameters } = getInputsParameters(m, empty as never, region);
+        expect(parameters[paramId]).toBeUndefined();
+    });
+
+    test("uses binding value when provided", () => {
+        const m = buildModel([{ id: paramId, type: "int" }]);
+        const b: Record<string, string> = { [paramId]: "42" };
+        const { parameters, parameterTypes } = getInputsParameters(m, b as never, region);
+        expect(parameters[paramId]).toBe("42");
+        expect(parameterTypes[paramId]).toBe("int");
+    });
+
+    test("falls back to ip.value default", () => {
+        const m = buildModel([{ id: paramId, type: "string", value: "default" }]);
+        const { parameters } = getInputsParameters(m, {} as never, region);
+        expect(parameters[paramId]).toBe("default");
+    });
 });


### PR DESCRIPTION
## Summary
- Treat empty-string parameter bindings as unset in `submitExecutions` to avoid Tapis crash
- Add regression tests in `src/classes/tapis/tests/helpers.test.ts`
- Bump Dockerfile base image to Node 24

## Test plan
- [ ] `npm test` passes locally
- [ ] Submit execution with a parameter bound to "" and confirm no crash