### PR TITLE
fix(tapis): map Hasura output shape in getModelOutputsByModelId

### DIFF
--- a/src/classes/graphql/graphql_functions.test.ts
+++ b/src/classes/graphql/graphql_functions.test.ts
@@ -1,0 +1,63 @@
+import { mapHasuraOutputsToModelOutputs } from "@/classes/graphql/graphql_functions";
+
+describe("mapHasuraOutputsToModelOutputs", () => {
+    it("maps Hasura configuration outputs to ModelOutput[]", () => {
+        const hasuraOutputs = [
+            {
+                output: {
+                    id: "https://w3id.org/okn/i/mint/cdd558dc",
+                    label: "out.txt",
+                    has_format: "txt",
+                    description: "Message",
+                    __typename: "modelcatalog_dataset_specification"
+                },
+                __typename: "modelcatalog_configuration_output"
+            }
+        ];
+
+        const result = mapHasuraOutputsToModelOutputs(hasuraOutputs);
+
+        expect(result).toEqual([
+            {
+                position: 1,
+                model_io: {
+                    id: "https://w3id.org/okn/i/mint/cdd558dc",
+                    name: "out.txt",
+                    format: "txt",
+                    variables: []
+                }
+            }
+        ]);
+    });
+
+    it("returns [] for null/undefined/empty input", () => {
+        expect(mapHasuraOutputsToModelOutputs(null)).toEqual([]);
+        expect(mapHasuraOutputsToModelOutputs(undefined)).toEqual([]);
+        expect(mapHasuraOutputsToModelOutputs([])).toEqual([]);
+    });
+
+    it("skips entries with missing output", () => {
+        const result = mapHasuraOutputsToModelOutputs([
+            { output: null },
+            {
+                output: {
+                    id: "id-1",
+                    label: "a.tif",
+                    has_format: "tif"
+                }
+            }
+        ]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].model_io.name).toBe("a.tif");
+    });
+
+    it("handles missing label and has_format", () => {
+        const result = mapHasuraOutputsToModelOutputs([
+            { output: { id: "id-1" } }
+        ]);
+
+        expect(result[0].model_io.name).toBe("");
+        expect(result[0].model_io.format).toBeUndefined();
+    });
+});

--- a/src/classes/graphql/graphql_functions.ts
+++ b/src/classes/graphql/graphql_functions.ts
@@ -1124,6 +1124,34 @@ export const getRegionDetails = (regionid: string) => {
     });
 };
 
+interface HasuraConfigurationOutputEntry {
+    output?: {
+        id: string;
+        label?: string | null;
+        has_format?: string | null;
+    } | null;
+}
+
+export const mapHasuraOutputsToModelOutputs = (
+    outputs: HasuraConfigurationOutputEntry[] | null | undefined
+): ModelOutput[] => {
+    if (!Array.isArray(outputs)) return [];
+    return outputs
+        .filter(
+            (entry): entry is HasuraConfigurationOutputEntry & { output: NonNullable<HasuraConfigurationOutputEntry["output"]> } =>
+                !!entry && !!entry.output
+        )
+        .map((entry, index) => ({
+            position: index + 1,
+            model_io: {
+                id: entry.output.id,
+                name: entry.output.label ?? "",
+                format: entry.output.has_format ?? undefined,
+                variables: []
+            }
+        }));
+};
+
 export const getModelOutputsByModelId = async (modelId: string): Promise<ModelOutput[]> => {
     const APOLLO_CLIENT = GraphQL.instance(KeycloakAdapter.getUser());
     return APOLLO_CLIENT.query({
@@ -1136,18 +1164,15 @@ export const getModelOutputsByModelId = async (modelId: string): Promise<ModelOu
             if (!result || (result.errors && result.errors.length > 0)) {
                 console.log("ERROR");
                 console.log(result);
-            } else {
-                const model = result.data.modelcatalog_configuration_by_pk;
-                if (model) {
-                    return model.outputs;
-                }
+                return [];
             }
-            return null;
+            const model = result.data.modelcatalog_configuration_by_pk;
+            return mapHasuraOutputsToModelOutputs(model?.outputs);
         })
         .catch((e) => {
             console.log("ERROR");
             console.log(e);
-            return null;
+            return [];
         });
 };
 


### PR DESCRIPTION
## Summary
- `matchTapisOutputsToMintOutputs` crashed in production with `TypeError: Cannot read properties of undefined (reading 'name')` when fetching subtask outputs.
- Root cause: `getModelOutputsByModelId` returned the raw Hasura response (`outputs[].output.{id,label,has_format}`) while typed as `ModelOutput[]` (`{position, model_io:{id,name,format,variables}}`). The matcher accessed `mintOutput.model_io.name` on the raw shape and threw. DYNAMO v2.0 migration debt — type lied; test fixture used the typed shape so unit tests passed while prod failed.
- Fix: extract pure `mapHasuraOutputsToModelOutputs` and call it inside `getModelOutputsByModelId`. Return `[]` instead of `null` on errors to match the declared return type.

## Test plan
- [x] `npx jest src/classes/graphql/graphql_functions.test.ts` — 4/4 pass (real Hasura payload, null/undefined input, missing fields, missing label/has_format)
- [x] `npx jest` full suite — 77/77 pass (includes existing `matchTapisOutputsToMintOutputs` test)
- [x] `npm run build` — webpack compiles clean
- [ ] Manual: hit `GET /v1/problemStatements/.../subtasks/.../outputs` against a Tapis-backed execution and confirm 200 with mapped results