### PR TITLE
fix(tapis): skip optional inputs without bindings in ExecutionCreation

### DIFF
--- a/src/classes/common/ExecutionCreation.ts
+++ b/src/classes/common/ExecutionCreation.ts
@@ -334,6 +334,14 @@ export class ExecutionCreation {
     ): string[] {
         const inputIds = [];
         modelInputFiles.forEach((io) => {
+            // Optional inputs without a user binding or fixed value contribute no
+            // values to the cartesian product — including their id would push an
+            // undefined slot into cartProd and crash. Downstream Tapis/localex
+            // adapters tolerate the missing key.
+            if (io.is_optional && !io.value && !threadModel.bindings[io.id]) {
+                return;
+            }
+
             inputIds.push(io.id);
 
             if (!io.value) {

--- a/src/classes/common/__tests__/ExecutionCreationStatic.test.ts
+++ b/src/classes/common/__tests__/ExecutionCreationStatic.test.ts
@@ -286,6 +286,63 @@ describe("ExecutionCreation", () => {
             expect(inputIds).toContain("file2");
             expect(modelEnsemble.bindings["file2"].length).toBe(1);
         });
+
+        it("should skip optional input with no binding and no value", () => {
+            modelInputs.push({
+                id: "optional1",
+                name: "Optional Input",
+                position: 2,
+                type: "file",
+                variables: [],
+                is_optional: true
+            });
+
+            const inputIds = ExecutionCreation.processInputFiles(
+                modelInputs,
+                modelEnsemble,
+                thread
+            );
+            expect(inputIds).not.toContain("optional1");
+            expect(modelEnsemble.bindings["optional1"]).toBeUndefined();
+        });
+
+        it("should keep optional input that has a user-provided binding", () => {
+            modelInputs.push({
+                id: "optional1",
+                name: "Optional Input",
+                position: 2,
+                type: "file",
+                variables: [],
+                is_optional: true
+            });
+            modelEnsemble.bindings["optional1"] = ["datasetType2"];
+
+            const inputIds = ExecutionCreation.processInputFiles(
+                modelInputs,
+                modelEnsemble,
+                thread
+            );
+            expect(inputIds).toContain("optional1");
+            expect(modelEnsemble.bindings["optional1"].length).toBe(2);
+        });
+
+        it("should keep required input with no binding (preserve existing behavior)", () => {
+            modelInputs.push({
+                id: "required1",
+                name: "Required Input",
+                position: 2,
+                type: "file",
+                variables: []
+            });
+
+            const inputIds = ExecutionCreation.processInputFiles(
+                modelInputs,
+                modelEnsemble,
+                thread
+            );
+            expect(inputIds).toContain("required1");
+            expect(modelEnsemble.bindings["required1"]).toBeUndefined();
+        });
     });
 
     describe("processInputParameterCollection", () => {


### PR DESCRIPTION
## Summary

`POST /executionEngines/tapis` crashes with `TypeError: Cannot read properties of undefined (reading 'length')` whenever a model has an optional input (`is_optional: true`) that the user did not bind to a dataset.

`ExecutionCreation.processInputFiles` unconditionally pushed every model input id into the list passed to `cartProd`. The optional input had no entry in `threadModel.bindings`, so the corresponding slot in the cart-product list was `undefined`, and `cartProd` then read `undefined.length`. The crash happens before the stage-2 skip added in phase 12-04 (`TapisJobService.createJobFileInputsFromSeed`) ever runs.

The fix skips optional inputs that have neither a user binding nor a fixed value — they contribute nothing to the cartesian product and downstream Tapis/localex adapters already tolerate the missing key.

## Changes

- `src/classes/common/ExecutionCreation.ts`: in `processInputFiles`, early-return for `is_optional=true && !value && !bindings[id]`. Required inputs and optional inputs with a binding are unchanged.
- `src/classes/common/__tests__/ExecutionCreationStatic.test.ts`: three new tests covering the optional-skip, optional-with-binding, and required-no-binding branches.

## Test plan

- [x] `npx jest` — 80/80 pass
- [x] `npm run build` — webpack compiles
- [ ] Manual: submit a thread with an optional input left unbound to /executionEngines/tapis and confirm no crash + Tapis job submitted